### PR TITLE
Fix MFLES API migration and add missing build sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ set(ANOFOX_TIME_SOURCES
     anofox-time/src/utils/metrics.cpp
     anofox-time/src/utils/nelder_mead.cpp
     anofox-time/src/utils/intermittent_utils.cpp
+    anofox-time/src/utils/robust_regression.cpp
+    anofox-time/src/utils/cross_validation.cpp
     # Optimization
     anofox-time/src/optimization/lbfgs_optimizer.cpp
     anofox-time/src/optimization/ets_gradients.cpp

--- a/guides/templates/41_model_parameters.md.in
+++ b/guides/templates/41_model_parameters.md.in
@@ -466,9 +466,9 @@ Gradient-boosted decomposition for multiple seasonal patterns.
 |-----------|------|----------|---------|-------------|
 | `seasonal_periods` | INTEGER[] | No | [12] | Array of seasonal periods |
 | `n_iterations` | INTEGER | No | 10 | Number of gradient boosting iterations |
-| `lr_trend` | DOUBLE | No | 0.3 | Learning rate for trend |
-| `lr_season` | DOUBLE | No | 0.5 | Learning rate for seasonality |
-| `lr_level` | DOUBLE | No | 0.8 | Learning rate for level |
+| `lr_trend` | DOUBLE | No | 0.3 | Learning rate for trend component |
+| `lr_season` | DOUBLE | No | 0.5 | Learning rate for seasonality component |
+| `lr_level` | DOUBLE | No | 0.8 | Learning rate for residual smoothing (ES ensemble) |
 
 **Validation:**
 - All seasonal periods must be positive

--- a/src/anofox_time_wrapper.cpp
+++ b/src/anofox_time_wrapper.cpp
@@ -188,14 +188,22 @@ AnofoxTimeWrapper::CreateMFLES(const std::vector<int> &seasonal_periods, int n_i
                                double lr_season, double lr_level) {
 	// std::cerr << "[DEBUG] AnofoxTimeWrapper::CreateMFLES with " << seasonal_periods.size() << " periods" <<
 	// std::endl;
-	return std::make_unique<::anofoxtime::models::MFLES>(seasonal_periods, n_iterations, lr_trend, lr_season, lr_level);
+	::anofoxtime::models::MFLES::Params params;
+	params.seasonal_periods = seasonal_periods;
+	params.max_rounds = n_iterations;
+	params.lr_trend = lr_trend;
+	params.lr_season = lr_season;
+	params.lr_rs = lr_level;
+	return std::make_unique<::anofoxtime::models::MFLES>(params);
 }
 
 std::unique_ptr<::anofoxtime::models::IForecaster>
 AnofoxTimeWrapper::CreateAutoMFLES(const std::vector<int> &seasonal_periods) {
 	// std::cerr << "[DEBUG] AnofoxTimeWrapper::CreateAutoMFLES with " << seasonal_periods.size() << " periods" <<
 	// std::endl;
-	return std::make_unique<::anofoxtime::models::AutoMFLES>(seasonal_periods);
+	::anofoxtime::models::AutoMFLES::Config config;
+	config.seasonal_periods = seasonal_periods;
+	return std::make_unique<::anofoxtime::models::AutoMFLES>(config);
 }
 
 std::unique_ptr<::anofoxtime::models::IForecaster>


### PR DESCRIPTION
- Update MFLES/AutoMFLES wrappers to use new Params/Config structs
- Map lr_level parameter to lr_rs (residual smoothing learning rate)
- Add missing source files to CMakeLists.txt:
  - anofox-time/src/utils/robust_regression.cpp
  - anofox-time/src/utils/cross_validation.cpp
- Update MFLES parameter documentation for clarity

Fixes linker errors for RobustRegression::siegelRepeatedMedians and CrossValidation::evaluate functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)