### PR TITLE
feat: add resilience parameter to ts_mstl_decomposition

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1051,6 +1051,10 @@ anofox_fcst_ts_mstl_decomposition(
 - `value_col`: Value column name as string literal or column reference
 - `params`: Configuration MAP with the following keys:
   - `seasonal_periods` (INTEGER[], required): Array of seasonal periods to decompose (e.g., `[7, 30]` for weekly and monthly patterns)
+  - `insufficient_data` (VARCHAR, optional): Controls behavior when a series has insufficient data for MSTL decomposition. Default: `'trend'`
+    - `'fail'`: Throw an error (original behavior)
+    - `'trend'`: Apply trend-only decomposition using moving average; seasonal columns filled with NULL, residual = value - trend
+    - `'none'`: No decomposition; all decomposition columns (trend, seasonal_*, residual) filled with NULL
 
 **Minimum Series Length:**
 - Each series must have at least `2 × min(seasonal_periods)` observations

--- a/test/sql/mstl_decomposition.test
+++ b/test/sql/mstl_decomposition.test
@@ -103,6 +103,172 @@ SELECT COUNT(*) FROM result_mstl_alias;
 ----
 101
 
+#############################################
+# INSUFFICIENT DATA HANDLING TESTS
+#############################################
+
+# Create a series with insufficient data for period=7 (needs at least 14 points, we have 5)
+statement ok
+CREATE TABLE test_insufficient AS
+SELECT
+    ('2024-01-01'::DATE + INTERVAL (i) DAY) AS date_col,
+    'short_series' AS group_col,
+    100.0 + i AS value_col
+FROM generate_series(0, 4) t(i);
+
+# Test 5: insufficient_data = 'fail' - should throw error
+statement error
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_insufficient',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7], 'insufficient_data': 'fail'}
+);
+----
+MSTL decomposition failed for group
+
+# Test 6: insufficient_data = 'trend' (default) - trend populated, seasonal=NULL, residual=value-trend
+statement ok
+CREATE TABLE result_insufficient_trend AS
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_insufficient',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7], 'insufficient_data': 'trend'}
+);
+
+# Verify trend is NOT NULL
+query I
+SELECT COUNT(*) FROM result_insufficient_trend WHERE trend IS NOT NULL;
+----
+5
+
+# Verify seasonal_7 IS NULL
+query I
+SELECT COUNT(*) FROM result_insufficient_trend WHERE seasonal_7 IS NULL;
+----
+5
+
+# Verify residual is NOT NULL (residual = value - trend)
+query I
+SELECT COUNT(*) FROM result_insufficient_trend WHERE residual IS NOT NULL;
+----
+5
+
+# Verify additivity with NULL seasonality: value_col = trend + residual (since seasonal is NULL)
+query I
+SELECT AVG(ABS(value_col - (trend + residual))) < 0.001 FROM result_insufficient_trend;
+----
+true
+
+# Test 7: insufficient_data = 'none' - all decomposition columns = NULL
+statement ok
+CREATE TABLE result_insufficient_none AS
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_insufficient',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7], 'insufficient_data': 'none'}
+);
+
+# Verify all decomposition columns are NULL
+query I
+SELECT COUNT(*) FROM result_insufficient_none WHERE trend IS NULL AND seasonal_7 IS NULL AND residual IS NULL;
+----
+5
+
+# Test 8: Default behavior (no insufficient_data specified) - should default to 'trend'
+statement ok
+CREATE TABLE result_insufficient_default AS
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_insufficient',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7]}
+);
+
+# Verify default behavior matches 'trend' mode
+query I
+SELECT COUNT(*) FROM result_insufficient_default WHERE trend IS NOT NULL AND seasonal_7 IS NULL;
+----
+5
+
+# Test 9: Mixed series - some sufficient, some insufficient
+statement ok
+CREATE TABLE test_mixed AS
+SELECT * FROM (
+    -- Short series (insufficient data)
+    SELECT
+        ('2024-01-01'::DATE + INTERVAL (i) DAY) AS date_col,
+        'short' AS group_col,
+        100.0 + i AS value_col
+    FROM generate_series(0, 4) t(i)
+    UNION ALL
+    -- Long series (sufficient data)
+    SELECT
+        ('2024-01-01'::DATE + INTERVAL (i) DAY) AS date_col,
+        'long' AS group_col,
+        100.0 + i + sin(i * 2 * 3.14159 / 7.0) * 10 AS value_col
+    FROM generate_series(0, 100) t(i)
+);
+
+statement ok
+CREATE TABLE result_mixed AS
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_mixed',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7], 'insufficient_data': 'trend'}
+);
+
+# Short series should have NULL seasonal
+query I
+SELECT COUNT(*) FROM result_mixed WHERE group_col = 'short' AND seasonal_7 IS NULL;
+----
+5
+
+# Long series should have non-NULL seasonal
+query I
+SELECT COUNT(*) FROM result_mixed WHERE group_col = 'long' AND seasonal_7 IS NOT NULL;
+----
+101
+
+# Test 10: Invalid insufficient_data mode
+statement error
+SELECT * FROM ts_mstl_decomposition(
+    table_name='test_insufficient',
+    group_col='group_col',
+    date_col='date_col',
+    value_col='value_col',
+    params={'seasonal_periods': [7], 'insufficient_data': 'invalid_mode'}
+);
+----
+Invalid insufficient_data mode
+
+# Cleanup insufficient data tests
+statement ok
+DROP TABLE IF EXISTS test_insufficient;
+
+statement ok
+DROP TABLE IF EXISTS result_insufficient_trend;
+
+statement ok
+DROP TABLE IF EXISTS result_insufficient_none;
+
+statement ok
+DROP TABLE IF EXISTS result_insufficient_default;
+
+statement ok
+DROP TABLE IF EXISTS test_mixed;
+
+statement ok
+DROP TABLE IF EXISTS result_mixed;
+
 # Cleanup
 statement ok
 DROP TABLE IF EXISTS test_mstl_basic;


### PR DESCRIPTION
## Summary

This PR adds an `insufficient_data` parameter to `TS_MSTL_DECOMPOSITION` that controls behavior when time series have insufficient data for seasonal decomposition (fewer than `2 * max_period` data points).

### New Parameter: `insufficient_data`

| Mode | Behavior |
|------|----------|
| `'fail'` | Query fails with descriptive error when any series has insufficient data (original behavior) |
| `'trend'` (default) | Apply trend-only decomposition using moving average; seasonal columns = NULL; residual = value - trend |
| `'none'` | No decomposition performed; all decomposition columns (trend, seasonal_*, residual) = NULL |

### Technical Changes

1. **MaxThreads() Fix**: Added `MaxThreads()` override to `TSMstlDecompositionGlobalState` returning 1 to avoid BatchedDataCollection merge errors (DuckDB issue #19939)

2. **Fallback Logic**: When MSTL decomposition fails due to insufficient data:
   - `'trend'` mode: Computes trend via moving average, sets seasonal to NULL, calculates residual as `value - trend`
   - `'none'` mode: All decomposition columns output as NULL
   - `'fail'` mode: Throws descriptive error (original behavior)

3. **Mixed Series Support**: Each series is handled independently - sufficient series get full MSTL decomposition while insufficient series use the fallback mode

### Example Usage

```sql
-- Default behavior (trend mode) - tolerates insufficient data
SELECT * FROM ts_mstl_decomposition(
    table_name='my_data',
    group_col='series_id', 
    date_col='date',
    value_col='value',
    params={'seasonal_periods': [7]}
);

-- Explicit fail mode - strict validation
SELECT * FROM ts_mstl_decomposition(
    table_name='my_data',
    group_col='series_id',
    date_col='date', 
    value_col='value',
    params={'seasonal_periods': [7], 'insufficient_data': 'fail'}
);

-- None mode - skip decomposition for insufficient series
SELECT * FROM ts_mstl_decomposition(
    table_name='my_data',
    group_col='series_id',
    date_col='date',
    value_col='value', 
    params={'seasonal_periods': [7], 'insufficient_data': 'none'}
);
```

## Test Plan

- [x] Test 'fail' mode throws error for insufficient series
- [x] Test 'trend' mode returns trend + NULL seasonal + residual
- [x] Test 'none' mode returns all NULL decomposition columns
- [x] Test default behavior (no param) uses 'trend' mode
- [x] Test mixed series (some sufficient, some insufficient)
- [x] Test invalid mode value throws error
- [x] Verify additivity: `value = trend + residual` when seasonal is NULL
- [x] All 40 MSTL test assertions pass

Closes #42