### PR TITLE
fix: enable include_probabilities parameter in changepoint detection

### DIFF
--- a/test/sql/changepoint/test_changepoint_probabilities.test
+++ b/test/sql/changepoint/test_changepoint_probabilities.test
@@ -61,11 +61,10 @@ FROM anofox_fcst_ts_detect_changepoints('cp_test', ds, y, {'include_probabilitie
 ----
 true
 
-# Test 6: Verify probabilities exist but are currently 0.0 (parameter parsing TODO)
-# NOTE: The include_probabilities parameter is not currently being parsed correctly
-# through the table function macro. This needs further investigation.
+# Test 6: When include_probabilities=true, probabilities should be non-zero
+# (BOCPD algorithm produces changepoint probabilities > 0)
 query I
-SELECT MAX(changepoint_probability) >= 0.0
+SELECT MAX(changepoint_probability) > 0.0
 FROM anofox_fcst_ts_detect_changepoints('cp_test', ds, y, {'include_probabilities': true});
 ----
 true
@@ -133,10 +132,17 @@ true
 
 # Test 13: Multi-series without include_probabilities has all probabilities as 0.0
 query I
-SELECT 
-    MIN(changepoint_probability) = 0.0 AND 
+SELECT
+    MIN(changepoint_probability) = 0.0 AND
     MAX(changepoint_probability) = 0.0
 FROM anofox_fcst_ts_detect_changepoints_by('multi_test', id, ds, y, MAP{});
+----
+true
+
+# Test 14: Multi-series with include_probabilities=true should have non-zero probabilities
+query I
+SELECT MAX(changepoint_probability) > 0.0
+FROM anofox_fcst_ts_detect_changepoints_by('multi_test', id, ds, y, {'include_probabilities': true});
 ----
 true
 


### PR DESCRIPTION
## Summary

Fixes the `include_probabilities` parameter not working in `TS_DETECT_CHANGEPOINTS` and `TS_DETECT_CHANGEPOINTS_BY` table macros.

### Problem

When users passed `{'include_probabilities': true}`, changepoint probabilities were always returned as 0.0 instead of actual probability values from the BOCPD algorithm.

### Root Cause

The parameter parsing code checked for `LogicalTypeId::MAP` when DuckDB's `{'key': value}` syntax creates a **STRUCT** type. This caused the condition to always be false, so parameters were never parsed.

### Solution

Adopted the same bind-time parameter parsing pattern used in `forecast_aggregate.cpp`:

- Added `TSDetectChangepointsBindData` struct to store parameters
- Added `TSDetectChangepointsBind` function that parses `include_probabilities` and `hazard_lambda` from STRUCT type at bind time
- Updated `Finalize` function to read parameters from bind data
- Simplified `Update` function to only collect time series data

### Changes

- `src/changepoint_function.cpp`: Refactored to use bind-time parameter parsing
- `test/sql/changepoint/test_changepoint_probabilities.test`: Updated tests to verify non-zero probabilities

### Testing

- All changepoint tests pass (52 assertions)
- Verified manually that `{'include_probabilities': true}` now returns non-zero probabilities
- Verified that default behavior still returns all 0.0 probabilities
- Both single-series and multi-series (`_by`) variants work correctly