### PR TITLE
refactor: Return expanded table columns instead of structs for all _by macros

### DIFF
--- a/docs/api/03-statistics.md
+++ b/docs/api/03-statistics.md
@@ -64,11 +64,6 @@ ts_stats_by(source VARCHAR, group_col COLUMN, date_col COLUMN, value_col COLUMN,
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | (same as group_col) | Series identifier |
-| `stats` | STRUCT | Statistics struct (see fields below) |
-
-**Stats STRUCT fields:**
-| Field | Type | Description |
-|-------|------|-------------|
 | `length` | UBIGINT | Total number of observations |
 | `n_nulls` | UBIGINT | Number of NULL values |
 | `n_nan` | UBIGINT | Number of NaN values |
@@ -114,21 +109,21 @@ SELECT * FROM ts_stats_by('sales', product_id, date, quantity, '1d');
 -- Access specific fields
 SELECT
     id,
-    (stats).length,
-    (stats).mean,
-    (stats).std_dev,
-    (stats).trend_strength
+    length,
+    mean,
+    std_dev,
+    trend_strength
 FROM ts_stats_by('sales', product_id, date, quantity, '1d');
 
 -- Detect gaps in time series
 SELECT
     id,
-    (stats).length AS actual_length,
-    (stats).expected_length,
-    (stats).n_gaps,
-    CASE WHEN (stats).n_gaps > 0 THEN 'Has gaps' ELSE 'Complete' END AS status
+    length AS actual_length,
+    expected_length,
+    n_gaps,
+    CASE WHEN n_gaps > 0 THEN 'Has gaps' ELSE 'Complete' END AS status
 FROM ts_stats_by('sales', product_id, date, quantity, '1d')
-WHERE (stats).n_gaps > 0;
+WHERE n_gaps > 0;
 ```
 
 > **Alias:** `ts_stats` is an alias for `ts_stats_by`
@@ -157,12 +152,7 @@ ts_data_quality_by(source VARCHAR, group_col COLUMN, date_col COLUMN, value_col 
 **Returns:**
 | Column | Type | Description |
 |--------|------|-------------|
-| `id` | (same as group_col) | Series identifier |
-| `quality` | STRUCT | Quality assessment struct (see fields below) |
-
-**Quality STRUCT fields:**
-| Field | Type | Description |
-|-------|------|-------------|
+| `unique_id` | (same as group_col) | Series identifier |
 | `structural_score` | DOUBLE | Structural dimension score (0-1) - measures data completeness |
 | `temporal_score` | DOUBLE | Temporal dimension score (0-1) - measures regularity of timestamps |
 | `magnitude_score` | DOUBLE | Magnitude dimension score (0-1) - measures value distribution health |
@@ -179,16 +169,16 @@ SELECT * FROM ts_data_quality_by('sales', product_id, date, quantity, 10, '1d');
 
 -- Access specific fields
 SELECT
-    id,
-    (quality).overall_score,
-    (quality).n_gaps,
-    (quality).is_constant
+    unique_id,
+    overall_score,
+    n_gaps,
+    is_constant
 FROM ts_data_quality_by('sales', product_id, date, quantity, 10, '1d');
 
 -- Filter for high-quality series
-SELECT id
+SELECT unique_id
 FROM ts_data_quality_by('sales', product_id, date, quantity, 10, '1d')
-WHERE (quality).overall_score > 0.8;
+WHERE overall_score > 0.8;
 ```
 
 > **Alias:** `ts_data_quality` is an alias for `ts_data_quality_by`

--- a/docs/api/05a-decomposition.md
+++ b/docs/api/05a-decomposition.md
@@ -69,11 +69,6 @@ ts_classify_seasonality_by(source VARCHAR, group_col COLUMN, date_col COLUMN, va
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | (same as group_col) | Group identifier |
-| `classification` | STRUCT | Classification results (see fields below) |
-
-**Classification STRUCT fields:**
-| Field | Type | Description |
-|-------|------|-------------|
 | `timing_classification` | VARCHAR | 'early', 'on_time', 'late', or 'variable' |
 | `modulation_type` | VARCHAR | 'stable', 'growing', 'shrinking', or 'variable' |
 | `has_stable_timing` | BOOLEAN | Whether peak timing is consistent |
@@ -89,9 +84,9 @@ ts_classify_seasonality_by(source VARCHAR, group_col COLUMN, date_col COLUMN, va
 SELECT * FROM ts_classify_seasonality_by('sales', product_id, date, quantity, 7.0);
 
 -- Find products with strong, stable seasonality
-SELECT id, (classification).seasonal_strength
+SELECT id, seasonal_strength
 FROM ts_classify_seasonality_by('sales', product_id, date, quantity, 7.0)
-WHERE (classification).is_seasonal AND (classification).has_stable_timing;
+WHERE is_seasonal AND has_stable_timing;
 ```
 
 ---
@@ -113,7 +108,7 @@ ts_classify_seasonality(source VARCHAR, date_col COLUMN, value_col COLUMN, perio
 | `value_col` | COLUMN | Value column |
 | `period` | DOUBLE | Expected seasonal period |
 
-**Returns:** Single row with `classification` STRUCT (same fields as above).
+**Returns:** Single row with classification columns (same columns as `ts_classify_seasonality_by` without `id`).
 
 **Example:**
 ```sql
@@ -122,9 +117,9 @@ SELECT * FROM ts_classify_seasonality('daily_sales', date, amount, 7.0);
 
 -- Check if seasonality is strong and stable
 SELECT
-    (classification).is_seasonal,
-    (classification).seasonal_strength,
-    (classification).has_stable_timing
+    is_seasonal,
+    seasonal_strength,
+    has_stable_timing
 FROM ts_classify_seasonality('daily_sales', date, amount, 7.0);
 ```
 

--- a/docs/api/20-feature-extraction.md
+++ b/docs/api/20-feature-extraction.md
@@ -27,7 +27,7 @@ SELECT * FROM ts_features_table('daily_sales', date, value);
 SELECT * FROM ts_features_by('sales', product_id, date, quantity);
 
 -- Access specific features from result
-SELECT id, (features).mean, (features).standard_deviation
+SELECT id, mean, standard_deviation
 FROM ts_features_by('sales', product_id, date, quantity);
 ```
 
@@ -60,11 +60,7 @@ ts_features_by(source VARCHAR, group_col COLUMN, date_col COLUMN, value_col COLU
 | `date_col` | COLUMN | Date/timestamp column |
 | `value_col` | COLUMN | Value column |
 
-**Returns:**
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | (same as group_col) | Group identifier |
-| `features` | STRUCT | 117-field feature struct |
+**Returns:** TABLE with `id` and 116 feature columns including `mean`, `standard_deviation`, `skewness`, `kurtosis`, `length`, `linear_trend_slope`, `autocorrelation_lag1`, etc.
 
 **Example:**
 ```sql
@@ -72,9 +68,9 @@ ts_features_by(source VARCHAR, group_col COLUMN, date_col COLUMN, value_col COLU
 SELECT * FROM ts_features_by('sales', product_id, date, quantity);
 
 -- Filter by specific feature values
-SELECT id, (features).mean, (features).trend_strength
+SELECT id, mean, linear_trend_slope
 FROM ts_features_by('sales', product_id, date, quantity)
-WHERE (features).length > 30;
+WHERE length > 30;
 ```
 
 ---
@@ -95,7 +91,7 @@ ts_features_table(source VARCHAR, date_col COLUMN, value_col COLUMN) → TABLE
 | `date_col` | COLUMN | Date/timestamp column |
 | `value_col` | COLUMN | Value column |
 
-**Returns:** Single row with `features` STRUCT containing 117 feature columns.
+**Returns:** Single row with 116 feature columns including `mean`, `standard_deviation`, `skewness`, `kurtosis`, `length`, etc.
 
 **Example:**
 ```sql
@@ -103,7 +99,7 @@ ts_features_table(source VARCHAR, date_col COLUMN, value_col COLUMN) → TABLE
 SELECT * FROM ts_features_table('daily_revenue', date, amount);
 
 -- Access specific features from result
-SELECT (features).mean, (features).standard_deviation
+SELECT mean, standard_deviation
 FROM ts_features_table('daily_revenue', date, amount);
 ```
 

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -23,17 +23,59 @@ struct TsTableMacro {
 static const TsTableMacro ts_table_macros[] = {
     // ts_stats: Compute statistics for grouped time series
     // C++ API: ts_stats(table_name, group_col, date_col, value_col, frequency)
+    // Returns: TABLE with expanded statistics columns
     {"ts_stats", {"source", "group_col", "date_col", "value_col", "frequency", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH stats_data AS (
+    SELECT
+        group_col AS id,
+        _ts_stats_with_dates(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            LIST(date_col::TIMESTAMP ORDER BY date_col),
+            frequency::VARCHAR
+        ) AS _stats
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    _ts_stats_with_dates(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        LIST(date_col::TIMESTAMP ORDER BY date_col),
-        frequency::VARCHAR
-    ) AS stats
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_stats).length AS length,
+    (_stats).n_nulls AS n_nulls,
+    (_stats).n_nan AS n_nan,
+    (_stats).n_zeros AS n_zeros,
+    (_stats).n_positive AS n_positive,
+    (_stats).n_negative AS n_negative,
+    (_stats).n_unique_values AS n_unique_values,
+    (_stats).is_constant AS is_constant,
+    (_stats).n_zeros_start AS n_zeros_start,
+    (_stats).n_zeros_end AS n_zeros_end,
+    (_stats).plateau_size AS plateau_size,
+    (_stats).plateau_size_nonzero AS plateau_size_nonzero,
+    (_stats).mean AS mean,
+    (_stats).median AS median,
+    (_stats).std_dev AS std_dev,
+    (_stats).variance AS variance,
+    (_stats).min AS min,
+    (_stats).max AS max,
+    (_stats).range AS range,
+    (_stats).sum AS sum,
+    (_stats).skewness AS skewness,
+    (_stats).kurtosis AS kurtosis,
+    (_stats).tail_index AS tail_index,
+    (_stats).bimodality_coef AS bimodality_coef,
+    (_stats).trimmed_mean AS trimmed_mean,
+    (_stats).coef_variation AS coef_variation,
+    (_stats).q1 AS q1,
+    (_stats).q3 AS q3,
+    (_stats).iqr AS iqr,
+    (_stats).autocorr_lag1 AS autocorr_lag1,
+    (_stats).trend_strength AS trend_strength,
+    (_stats).seasonality_strength AS seasonality_strength,
+    (_stats).entropy AS entropy,
+    (_stats).stability AS stability,
+    (_stats).expected_length AS expected_length,
+    (_stats).n_gaps AS n_gaps
+FROM stats_data
 )"},
 
     // ts_quality_report: Generate quality report from stats table
@@ -41,10 +83,10 @@ GROUP BY group_col
     {"ts_quality_report", {"stats_table", "min_length", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT
-    SUM(CASE WHEN (stats).length >= min_length AND NOT (stats).is_constant THEN 1 ELSE 0 END) AS n_passed,
-    SUM(CASE WHEN (stats).n_nan > 0 THEN 1 ELSE 0 END) AS n_nan_issues,
-    SUM(CASE WHEN (stats).n_nulls > 0 THEN 1 ELSE 0 END) AS n_missing_issues,
-    SUM(CASE WHEN (stats).is_constant THEN 1 ELSE 0 END) AS n_constant,
+    SUM(CASE WHEN length >= min_length AND NOT is_constant THEN 1 ELSE 0 END) AS n_passed,
+    SUM(CASE WHEN n_nan > 0 THEN 1 ELSE 0 END) AS n_nan_issues,
+    SUM(CASE WHEN n_nulls > 0 THEN 1 ELSE 0 END) AS n_missing_issues,
+    SUM(CASE WHEN is_constant THEN 1 ELSE 0 END) AS n_constant,
     COUNT(*) AS n_total
 FROM query_table(stats_table::VARCHAR)
 )"},
@@ -55,42 +97,57 @@ FROM query_table(stats_table::VARCHAR)
 R"(
 SELECT
     COUNT(*) AS n_series,
-    AVG((stats).length) AS avg_length,
-    MIN((stats).length) AS min_length,
-    MAX((stats).length) AS max_length,
-    SUM((stats).n_nulls) AS total_nulls,
-    SUM((stats).n_nan) AS total_nans
+    AVG(length) AS avg_length,
+    MIN(length) AS min_length,
+    MAX(length) AS max_length,
+    SUM(n_nulls) AS total_nulls,
+    SUM(n_nan) AS total_nans
 FROM query_table(stats_table::VARCHAR)
 )"},
 
     // ts_data_quality: Assess data quality per series
     // C++ API: ts_data_quality(table_name, unique_id_col, date_col, value_col, n_short, frequency)
+    // Returns: TABLE with expanded quality columns
     {"ts_data_quality", {"source", "unique_id_col", "date_col", "value_col", "n_short", "frequency", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH quality_data AS (
+    SELECT
+        unique_id_col AS unique_id,
+        _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS _quality
+    FROM query_table(source::VARCHAR)
+    GROUP BY unique_id_col
+)
 SELECT
-    unique_id_col AS unique_id,
-    _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS quality
-FROM query_table(source::VARCHAR)
-GROUP BY unique_id_col
+    unique_id,
+    (_quality).structural_score AS structural_score,
+    (_quality).temporal_score AS temporal_score,
+    (_quality).magnitude_score AS magnitude_score,
+    (_quality).behavioral_score AS behavioral_score,
+    (_quality).overall_score AS overall_score,
+    (_quality).n_gaps AS n_gaps,
+    (_quality).n_missing AS n_missing,
+    (_quality).is_constant AS is_constant
+FROM quality_data
 )"},
 
     // ts_data_quality_summary: Summarize data quality across series
     // C++ API: ts_data_quality_summary(table_name, unique_id_col, date_col, value_col, n_short)
     {"ts_data_quality_summary", {"source", "unique_id_col", "date_col", "value_col", "n_short", nullptr}, {{nullptr, nullptr}},
 R"(
-SELECT
-    COUNT(*) AS n_total,
-    SUM(CASE WHEN (quality).overall_score >= 0.8 THEN 1 ELSE 0 END) AS n_good,
-    SUM(CASE WHEN (quality).overall_score >= 0.5 AND (quality).overall_score < 0.8 THEN 1 ELSE 0 END) AS n_fair,
-    SUM(CASE WHEN (quality).overall_score < 0.5 THEN 1 ELSE 0 END) AS n_poor,
-    AVG((quality).overall_score) AS avg_score
-FROM (
+WITH quality_data AS (
     SELECT
         unique_id_col AS unique_id,
-        _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS quality
+        _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS _quality
     FROM query_table(source::VARCHAR)
     GROUP BY unique_id_col
 )
+SELECT
+    COUNT(*) AS n_total,
+    SUM(CASE WHEN (_quality).overall_score >= 0.8 THEN 1 ELSE 0 END) AS n_good,
+    SUM(CASE WHEN (_quality).overall_score >= 0.5 AND (_quality).overall_score < 0.8 THEN 1 ELSE 0 END) AS n_fair,
+    SUM(CASE WHEN (_quality).overall_score < 0.5 THEN 1 ELSE 0 END) AS n_poor,
+    AVG((_quality).overall_score) AS avg_score
+FROM quality_data
 )"},
 
     // ts_drop_constant_by: Filter out constant series (table-based)
@@ -399,26 +456,49 @@ WHERE group_col IN (
 
     // ts_mstl_decomposition_by: MSTL decomposition for grouped series
     // C++ API: ts_mstl_decomposition_by(table_name, group_col, date_col, value_col, params MAP)
+    // Returns: TABLE with expanded decomposition columns
     {"ts_mstl_decomposition_by", {"source", "group_col", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH decomposition_data AS (
+    SELECT
+        group_col AS id,
+        _ts_mstl_decomposition(LIST(value_col::DOUBLE ORDER BY date_col)) AS _decomp
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    _ts_mstl_decomposition(LIST(value_col::DOUBLE ORDER BY date_col)) AS decomposition
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_decomp).trend AS trend,
+    (_decomp).seasonal AS seasonal,
+    (_decomp).remainder AS remainder,
+    (_decomp).periods AS periods
+FROM decomposition_data
 )"},
 
     // ts_classify_seasonality_by: Classify seasonality type per group
     // C++ API: ts_classify_seasonality_by(table_name, group_col, date_col, value_col, period)
-    // Returns: STRUCT(timing_classification, modulation_type, has_stable_timing, timing_variability,
-    //                 seasonal_strength, is_seasonal, cycle_strengths[], weak_seasons[])
+    // Returns: TABLE(id, timing_classification, modulation_type, has_stable_timing, timing_variability,
+    //                seasonal_strength, is_seasonal, cycle_strengths[], weak_seasons[])
     {"ts_classify_seasonality_by", {"source", "group_col", "date_col", "value_col", "period", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH classification_data AS (
+    SELECT
+        group_col AS id,
+        ts_classify_seasonality_agg(date_col, value_col::DOUBLE, period::DOUBLE) AS _cls
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    ts_classify_seasonality_agg(date_col, value_col::DOUBLE, period::DOUBLE) AS classification
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_cls).timing_classification AS timing_classification,
+    (_cls).modulation_type AS modulation_type,
+    (_cls).has_stable_timing AS has_stable_timing,
+    (_cls).timing_variability AS timing_variability,
+    (_cls).seasonal_strength AS seasonal_strength,
+    (_cls).is_seasonal AS is_seasonal,
+    (_cls).cycle_strengths AS cycle_strengths,
+    (_cls).weak_seasons AS weak_seasons
+FROM classification_data
 )"},
 
     // ts_detect_changepoints: Detect changepoints in a single series
@@ -2094,60 +2174,369 @@ FROM src
 
     // ts_stats_by: Alias for ts_stats (for API consistency with _by naming pattern)
     // C++ API: ts_stats_by(table_name, group_col, date_col, value_col, frequency)
+    // Returns: TABLE with expanded statistics columns
     {"ts_stats_by", {"source", "group_col", "date_col", "value_col", "frequency", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH stats_data AS (
+    SELECT
+        group_col AS id,
+        _ts_stats_with_dates(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            LIST(date_col::TIMESTAMP ORDER BY date_col),
+            frequency::VARCHAR
+        ) AS _stats
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    _ts_stats_with_dates(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        LIST(date_col::TIMESTAMP ORDER BY date_col),
-        frequency::VARCHAR
-    ) AS stats
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_stats).length AS length,
+    (_stats).n_nulls AS n_nulls,
+    (_stats).n_nan AS n_nan,
+    (_stats).n_zeros AS n_zeros,
+    (_stats).n_positive AS n_positive,
+    (_stats).n_negative AS n_negative,
+    (_stats).n_unique_values AS n_unique_values,
+    (_stats).is_constant AS is_constant,
+    (_stats).n_zeros_start AS n_zeros_start,
+    (_stats).n_zeros_end AS n_zeros_end,
+    (_stats).plateau_size AS plateau_size,
+    (_stats).plateau_size_nonzero AS plateau_size_nonzero,
+    (_stats).mean AS mean,
+    (_stats).median AS median,
+    (_stats).std_dev AS std_dev,
+    (_stats).variance AS variance,
+    (_stats).min AS min,
+    (_stats).max AS max,
+    (_stats).range AS range,
+    (_stats).sum AS sum,
+    (_stats).skewness AS skewness,
+    (_stats).kurtosis AS kurtosis,
+    (_stats).tail_index AS tail_index,
+    (_stats).bimodality_coef AS bimodality_coef,
+    (_stats).trimmed_mean AS trimmed_mean,
+    (_stats).coef_variation AS coef_variation,
+    (_stats).q1 AS q1,
+    (_stats).q3 AS q3,
+    (_stats).iqr AS iqr,
+    (_stats).autocorr_lag1 AS autocorr_lag1,
+    (_stats).trend_strength AS trend_strength,
+    (_stats).seasonality_strength AS seasonality_strength,
+    (_stats).entropy AS entropy,
+    (_stats).stability AS stability,
+    (_stats).expected_length AS expected_length,
+    (_stats).n_gaps AS n_gaps
+FROM stats_data
 )"},
 
     // ts_data_quality_by: Alias for ts_data_quality (for API consistency with _by naming pattern)
     // C++ API: ts_data_quality_by(table_name, unique_id_col, date_col, value_col, n_short, frequency)
+    // Returns: TABLE with expanded quality columns
     {"ts_data_quality_by", {"source", "unique_id_col", "date_col", "value_col", "n_short", "frequency", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH quality_data AS (
+    SELECT
+        unique_id_col AS unique_id,
+        _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS _quality
+    FROM query_table(source::VARCHAR)
+    GROUP BY unique_id_col
+)
 SELECT
-    unique_id_col AS unique_id,
-    _ts_data_quality(LIST(value_col::DOUBLE ORDER BY date_col)) AS quality
-FROM query_table(source::VARCHAR)
-GROUP BY unique_id_col
+    unique_id,
+    (_quality).structural_score AS structural_score,
+    (_quality).temporal_score AS temporal_score,
+    (_quality).magnitude_score AS magnitude_score,
+    (_quality).behavioral_score AS behavioral_score,
+    (_quality).overall_score AS overall_score,
+    (_quality).n_gaps AS n_gaps,
+    (_quality).n_missing AS n_missing,
+    (_quality).is_constant AS is_constant
+FROM quality_data
 )"},
 
     // ts_features_table: Extract features from a single-series table
     // C++ API: ts_features_table(table_name, date_col, value_col)
-    // Returns: STRUCT with all feature values
+    // Returns: TABLE with 117 expanded feature columns
     {"ts_features_table", {"source", "date_col", "value_col", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH features_data AS (
+    SELECT ts_features_agg(date_col, value_col::DOUBLE) AS _feat
+    FROM query_table(source::VARCHAR)
+)
 SELECT
-    ts_features_agg(date_col, value_col::DOUBLE) AS features
-FROM query_table(source::VARCHAR)
+    (_feat).abs_energy AS abs_energy,
+    (_feat).absolute_sum_of_changes AS absolute_sum_of_changes,
+    (_feat).agg_linear_trend_intercept AS agg_linear_trend_intercept,
+    (_feat).agg_linear_trend_rvalue AS agg_linear_trend_rvalue,
+    (_feat).agg_linear_trend_slope AS agg_linear_trend_slope,
+    (_feat).agg_linear_trend_stderr AS agg_linear_trend_stderr,
+    (_feat).approximate_entropy AS approximate_entropy,
+    (_feat).autocorrelation_lag1 AS autocorrelation_lag1,
+    (_feat).autocorrelation_lag2 AS autocorrelation_lag2,
+    (_feat).autocorrelation_lag3 AS autocorrelation_lag3,
+    (_feat).autocorrelation_lag4 AS autocorrelation_lag4,
+    (_feat).autocorrelation_lag5 AS autocorrelation_lag5,
+    (_feat).autocorrelation_lag6 AS autocorrelation_lag6,
+    (_feat).autocorrelation_lag7 AS autocorrelation_lag7,
+    (_feat).autocorrelation_lag8 AS autocorrelation_lag8,
+    (_feat).autocorrelation_lag9 AS autocorrelation_lag9,
+    (_feat).benford_correlation AS benford_correlation,
+    (_feat).binned_entropy AS binned_entropy,
+    (_feat).c3_lag1 AS c3_lag1,
+    (_feat).c3_lag2 AS c3_lag2,
+    (_feat).c3_lag3 AS c3_lag3,
+    (_feat).cid_ce AS cid_ce,
+    (_feat).count_above_mean AS count_above_mean,
+    (_feat).count_below_mean AS count_below_mean,
+    (_feat).count_unique AS count_unique,
+    (_feat).fft_coefficient_0_abs AS fft_coefficient_0_abs,
+    (_feat).fft_coefficient_0_imag AS fft_coefficient_0_imag,
+    (_feat).fft_coefficient_0_real AS fft_coefficient_0_real,
+    (_feat).fft_coefficient_1_abs AS fft_coefficient_1_abs,
+    (_feat).fft_coefficient_1_imag AS fft_coefficient_1_imag,
+    (_feat).fft_coefficient_1_real AS fft_coefficient_1_real,
+    (_feat).fft_coefficient_2_abs AS fft_coefficient_2_abs,
+    (_feat).fft_coefficient_2_imag AS fft_coefficient_2_imag,
+    (_feat).fft_coefficient_2_real AS fft_coefficient_2_real,
+    (_feat).fft_coefficient_3_abs AS fft_coefficient_3_abs,
+    (_feat).fft_coefficient_3_imag AS fft_coefficient_3_imag,
+    (_feat).fft_coefficient_3_real AS fft_coefficient_3_real,
+    (_feat).fft_coefficient_4_abs AS fft_coefficient_4_abs,
+    (_feat).fft_coefficient_4_imag AS fft_coefficient_4_imag,
+    (_feat).fft_coefficient_4_real AS fft_coefficient_4_real,
+    (_feat).fft_coefficient_5_abs AS fft_coefficient_5_abs,
+    (_feat).fft_coefficient_5_imag AS fft_coefficient_5_imag,
+    (_feat).fft_coefficient_5_real AS fft_coefficient_5_real,
+    (_feat).fft_coefficient_6_abs AS fft_coefficient_6_abs,
+    (_feat).fft_coefficient_6_imag AS fft_coefficient_6_imag,
+    (_feat).fft_coefficient_6_real AS fft_coefficient_6_real,
+    (_feat).fft_coefficient_7_abs AS fft_coefficient_7_abs,
+    (_feat).fft_coefficient_7_imag AS fft_coefficient_7_imag,
+    (_feat).fft_coefficient_7_real AS fft_coefficient_7_real,
+    (_feat).fft_coefficient_8_abs AS fft_coefficient_8_abs,
+    (_feat).fft_coefficient_8_imag AS fft_coefficient_8_imag,
+    (_feat).fft_coefficient_8_real AS fft_coefficient_8_real,
+    (_feat).fft_coefficient_9_abs AS fft_coefficient_9_abs,
+    (_feat).fft_coefficient_9_imag AS fft_coefficient_9_imag,
+    (_feat).fft_coefficient_9_real AS fft_coefficient_9_real,
+    (_feat).first_location_of_maximum AS first_location_of_maximum,
+    (_feat).first_location_of_minimum AS first_location_of_minimum,
+    (_feat).first_value AS first_value,
+    (_feat).has_duplicate AS has_duplicate,
+    (_feat).has_duplicate_max AS has_duplicate_max,
+    (_feat).has_duplicate_min AS has_duplicate_min,
+    (_feat).kurtosis AS kurtosis,
+    (_feat).large_standard_deviation AS large_standard_deviation,
+    (_feat).last_location_of_maximum AS last_location_of_maximum,
+    (_feat).last_location_of_minimum AS last_location_of_minimum,
+    (_feat).last_value AS last_value,
+    (_feat).lempel_ziv_complexity AS lempel_ziv_complexity,
+    (_feat).length AS length,
+    (_feat).linear_trend_intercept AS linear_trend_intercept,
+    (_feat).linear_trend_r_squared AS linear_trend_r_squared,
+    (_feat).linear_trend_slope AS linear_trend_slope,
+    (_feat).longest_strike_above_mean AS longest_strike_above_mean,
+    (_feat).longest_strike_below_mean AS longest_strike_below_mean,
+    (_feat).maximum AS maximum,
+    (_feat).mean AS mean,
+    (_feat).mean_abs_change AS mean_abs_change,
+    (_feat).mean_change AS mean_change,
+    (_feat).mean_second_derivative_central AS mean_second_derivative_central,
+    (_feat).median AS median,
+    (_feat).minimum AS minimum,
+    (_feat).number_peaks AS number_peaks,
+    (_feat).number_peaks_threshold_1 AS number_peaks_threshold_1,
+    (_feat).number_peaks_threshold_2 AS number_peaks_threshold_2,
+    (_feat).partial_autocorrelation_lag1 AS partial_autocorrelation_lag1,
+    (_feat).partial_autocorrelation_lag2 AS partial_autocorrelation_lag2,
+    (_feat).partial_autocorrelation_lag3 AS partial_autocorrelation_lag3,
+    (_feat).partial_autocorrelation_lag4 AS partial_autocorrelation_lag4,
+    (_feat).partial_autocorrelation_lag5 AS partial_autocorrelation_lag5,
+    (_feat).percentage_above_mean AS percentage_above_mean,
+    (_feat).percentage_of_reoccurring_datapoints_to_all_datapoints AS percentage_of_reoccurring_datapoints_to_all_datapoints,
+    (_feat).percentage_of_reoccurring_values_to_all_values AS percentage_of_reoccurring_values_to_all_values,
+    (_feat).permutation_entropy AS permutation_entropy,
+    (_feat)."quantile_0.1" AS "quantile_0.1",
+    (_feat)."quantile_0.25" AS "quantile_0.25",
+    (_feat)."quantile_0.75" AS "quantile_0.75",
+    (_feat)."quantile_0.9" AS "quantile_0.9",
+    (_feat).range AS range,
+    (_feat).ratio_beyond_r_sigma_1 AS ratio_beyond_r_sigma_1,
+    (_feat).ratio_beyond_r_sigma_2 AS ratio_beyond_r_sigma_2,
+    (_feat).ratio_beyond_r_sigma_3 AS ratio_beyond_r_sigma_3,
+    (_feat).ratio_value_number_to_length AS ratio_value_number_to_length,
+    (_feat).root_mean_square AS root_mean_square,
+    (_feat).sample_entropy AS sample_entropy,
+    (_feat).skewness AS skewness,
+    (_feat).spectral_centroid AS spectral_centroid,
+    (_feat).spectral_variance AS spectral_variance,
+    (_feat).standard_deviation AS standard_deviation,
+    (_feat).sum AS sum,
+    (_feat).sum_of_reoccurring_datapoints AS sum_of_reoccurring_datapoints,
+    (_feat).sum_of_reoccurring_values AS sum_of_reoccurring_values,
+    (_feat).time_reversal_asymmetry_stat_1 AS time_reversal_asymmetry_stat_1,
+    (_feat).time_reversal_asymmetry_stat_2 AS time_reversal_asymmetry_stat_2,
+    (_feat).time_reversal_asymmetry_stat_3 AS time_reversal_asymmetry_stat_3,
+    (_feat).variance AS variance,
+    (_feat).variation_coefficient AS variation_coefficient,
+    (_feat).zero_crossing_rate AS zero_crossing_rate
+FROM features_data
 )"},
 
     // ts_features_by: Extract features per group
     // C++ API: ts_features_by(table_name, group_col, date_col, value_col)
-    // Returns: TABLE(id, features STRUCT)
+    // Returns: TABLE with id and 117 expanded feature columns
     {"ts_features_by", {"source", "group_col", "date_col", "value_col", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH features_data AS (
+    SELECT
+        group_col AS id,
+        ts_features_agg(date_col, value_col::DOUBLE) AS _feat
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    ts_features_agg(date_col, value_col::DOUBLE) AS features
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_feat).abs_energy AS abs_energy,
+    (_feat).absolute_sum_of_changes AS absolute_sum_of_changes,
+    (_feat).agg_linear_trend_intercept AS agg_linear_trend_intercept,
+    (_feat).agg_linear_trend_rvalue AS agg_linear_trend_rvalue,
+    (_feat).agg_linear_trend_slope AS agg_linear_trend_slope,
+    (_feat).agg_linear_trend_stderr AS agg_linear_trend_stderr,
+    (_feat).approximate_entropy AS approximate_entropy,
+    (_feat).autocorrelation_lag1 AS autocorrelation_lag1,
+    (_feat).autocorrelation_lag2 AS autocorrelation_lag2,
+    (_feat).autocorrelation_lag3 AS autocorrelation_lag3,
+    (_feat).autocorrelation_lag4 AS autocorrelation_lag4,
+    (_feat).autocorrelation_lag5 AS autocorrelation_lag5,
+    (_feat).autocorrelation_lag6 AS autocorrelation_lag6,
+    (_feat).autocorrelation_lag7 AS autocorrelation_lag7,
+    (_feat).autocorrelation_lag8 AS autocorrelation_lag8,
+    (_feat).autocorrelation_lag9 AS autocorrelation_lag9,
+    (_feat).benford_correlation AS benford_correlation,
+    (_feat).binned_entropy AS binned_entropy,
+    (_feat).c3_lag1 AS c3_lag1,
+    (_feat).c3_lag2 AS c3_lag2,
+    (_feat).c3_lag3 AS c3_lag3,
+    (_feat).cid_ce AS cid_ce,
+    (_feat).count_above_mean AS count_above_mean,
+    (_feat).count_below_mean AS count_below_mean,
+    (_feat).count_unique AS count_unique,
+    (_feat).fft_coefficient_0_abs AS fft_coefficient_0_abs,
+    (_feat).fft_coefficient_0_imag AS fft_coefficient_0_imag,
+    (_feat).fft_coefficient_0_real AS fft_coefficient_0_real,
+    (_feat).fft_coefficient_1_abs AS fft_coefficient_1_abs,
+    (_feat).fft_coefficient_1_imag AS fft_coefficient_1_imag,
+    (_feat).fft_coefficient_1_real AS fft_coefficient_1_real,
+    (_feat).fft_coefficient_2_abs AS fft_coefficient_2_abs,
+    (_feat).fft_coefficient_2_imag AS fft_coefficient_2_imag,
+    (_feat).fft_coefficient_2_real AS fft_coefficient_2_real,
+    (_feat).fft_coefficient_3_abs AS fft_coefficient_3_abs,
+    (_feat).fft_coefficient_3_imag AS fft_coefficient_3_imag,
+    (_feat).fft_coefficient_3_real AS fft_coefficient_3_real,
+    (_feat).fft_coefficient_4_abs AS fft_coefficient_4_abs,
+    (_feat).fft_coefficient_4_imag AS fft_coefficient_4_imag,
+    (_feat).fft_coefficient_4_real AS fft_coefficient_4_real,
+    (_feat).fft_coefficient_5_abs AS fft_coefficient_5_abs,
+    (_feat).fft_coefficient_5_imag AS fft_coefficient_5_imag,
+    (_feat).fft_coefficient_5_real AS fft_coefficient_5_real,
+    (_feat).fft_coefficient_6_abs AS fft_coefficient_6_abs,
+    (_feat).fft_coefficient_6_imag AS fft_coefficient_6_imag,
+    (_feat).fft_coefficient_6_real AS fft_coefficient_6_real,
+    (_feat).fft_coefficient_7_abs AS fft_coefficient_7_abs,
+    (_feat).fft_coefficient_7_imag AS fft_coefficient_7_imag,
+    (_feat).fft_coefficient_7_real AS fft_coefficient_7_real,
+    (_feat).fft_coefficient_8_abs AS fft_coefficient_8_abs,
+    (_feat).fft_coefficient_8_imag AS fft_coefficient_8_imag,
+    (_feat).fft_coefficient_8_real AS fft_coefficient_8_real,
+    (_feat).fft_coefficient_9_abs AS fft_coefficient_9_abs,
+    (_feat).fft_coefficient_9_imag AS fft_coefficient_9_imag,
+    (_feat).fft_coefficient_9_real AS fft_coefficient_9_real,
+    (_feat).first_location_of_maximum AS first_location_of_maximum,
+    (_feat).first_location_of_minimum AS first_location_of_minimum,
+    (_feat).first_value AS first_value,
+    (_feat).has_duplicate AS has_duplicate,
+    (_feat).has_duplicate_max AS has_duplicate_max,
+    (_feat).has_duplicate_min AS has_duplicate_min,
+    (_feat).kurtosis AS kurtosis,
+    (_feat).large_standard_deviation AS large_standard_deviation,
+    (_feat).last_location_of_maximum AS last_location_of_maximum,
+    (_feat).last_location_of_minimum AS last_location_of_minimum,
+    (_feat).last_value AS last_value,
+    (_feat).lempel_ziv_complexity AS lempel_ziv_complexity,
+    (_feat).length AS length,
+    (_feat).linear_trend_intercept AS linear_trend_intercept,
+    (_feat).linear_trend_r_squared AS linear_trend_r_squared,
+    (_feat).linear_trend_slope AS linear_trend_slope,
+    (_feat).longest_strike_above_mean AS longest_strike_above_mean,
+    (_feat).longest_strike_below_mean AS longest_strike_below_mean,
+    (_feat).maximum AS maximum,
+    (_feat).mean AS mean,
+    (_feat).mean_abs_change AS mean_abs_change,
+    (_feat).mean_change AS mean_change,
+    (_feat).mean_second_derivative_central AS mean_second_derivative_central,
+    (_feat).median AS median,
+    (_feat).minimum AS minimum,
+    (_feat).number_peaks AS number_peaks,
+    (_feat).number_peaks_threshold_1 AS number_peaks_threshold_1,
+    (_feat).number_peaks_threshold_2 AS number_peaks_threshold_2,
+    (_feat).partial_autocorrelation_lag1 AS partial_autocorrelation_lag1,
+    (_feat).partial_autocorrelation_lag2 AS partial_autocorrelation_lag2,
+    (_feat).partial_autocorrelation_lag3 AS partial_autocorrelation_lag3,
+    (_feat).partial_autocorrelation_lag4 AS partial_autocorrelation_lag4,
+    (_feat).partial_autocorrelation_lag5 AS partial_autocorrelation_lag5,
+    (_feat).percentage_above_mean AS percentage_above_mean,
+    (_feat).percentage_of_reoccurring_datapoints_to_all_datapoints AS percentage_of_reoccurring_datapoints_to_all_datapoints,
+    (_feat).percentage_of_reoccurring_values_to_all_values AS percentage_of_reoccurring_values_to_all_values,
+    (_feat).permutation_entropy AS permutation_entropy,
+    (_feat)."quantile_0.1" AS "quantile_0.1",
+    (_feat)."quantile_0.25" AS "quantile_0.25",
+    (_feat)."quantile_0.75" AS "quantile_0.75",
+    (_feat)."quantile_0.9" AS "quantile_0.9",
+    (_feat).range AS range,
+    (_feat).ratio_beyond_r_sigma_1 AS ratio_beyond_r_sigma_1,
+    (_feat).ratio_beyond_r_sigma_2 AS ratio_beyond_r_sigma_2,
+    (_feat).ratio_beyond_r_sigma_3 AS ratio_beyond_r_sigma_3,
+    (_feat).ratio_value_number_to_length AS ratio_value_number_to_length,
+    (_feat).root_mean_square AS root_mean_square,
+    (_feat).sample_entropy AS sample_entropy,
+    (_feat).skewness AS skewness,
+    (_feat).spectral_centroid AS spectral_centroid,
+    (_feat).spectral_variance AS spectral_variance,
+    (_feat).standard_deviation AS standard_deviation,
+    (_feat).sum AS sum,
+    (_feat).sum_of_reoccurring_datapoints AS sum_of_reoccurring_datapoints,
+    (_feat).sum_of_reoccurring_values AS sum_of_reoccurring_values,
+    (_feat).time_reversal_asymmetry_stat_1 AS time_reversal_asymmetry_stat_1,
+    (_feat).time_reversal_asymmetry_stat_2 AS time_reversal_asymmetry_stat_2,
+    (_feat).time_reversal_asymmetry_stat_3 AS time_reversal_asymmetry_stat_3,
+    (_feat).variance AS variance,
+    (_feat).variation_coefficient AS variation_coefficient,
+    (_feat).zero_crossing_rate AS zero_crossing_rate
+FROM features_data
 )"},
 
     // ts_classify_seasonality: Classify seasonality for a single series
     // C++ API: ts_classify_seasonality(table_name, date_col, value_col, period)
-    // Returns: STRUCT with classification results
+    // Returns: TABLE(timing_classification, modulation_type, has_stable_timing, timing_variability,
+    //                seasonal_strength, is_seasonal, cycle_strengths[], weak_seasons[])
     {"ts_classify_seasonality", {"source", "date_col", "value_col", "period", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH classification_data AS (
+    SELECT
+        ts_classify_seasonality_agg(date_col, value_col::DOUBLE, period::DOUBLE) AS _cls
+    FROM query_table(source::VARCHAR)
+)
 SELECT
-    ts_classify_seasonality_agg(date_col, value_col::DOUBLE, period::DOUBLE) AS classification
-FROM query_table(source::VARCHAR)
+    (_cls).timing_classification AS timing_classification,
+    (_cls).modulation_type AS modulation_type,
+    (_cls).has_stable_timing AS has_stable_timing,
+    (_cls).timing_variability AS timing_variability,
+    (_cls).seasonal_strength AS seasonal_strength,
+    (_cls).is_seasonal AS is_seasonal,
+    (_cls).cycle_strengths AS cycle_strengths,
+    (_cls).weak_seasons AS weak_seasons
+FROM classification_data
 )"},
 
     // ================================================================================
@@ -2157,93 +2546,144 @@ FROM query_table(source::VARCHAR)
     // ts_detect_periods: Detect periods for a single series
     // C++ API: ts_detect_periods(table_name, date_col, value_col, params)
     // params: method (default 'fft') - 'fft' or 'acf'
-    // Returns: TABLE(periods STRUCT)
+    // Returns: TABLE with expanded period columns
     {"ts_detect_periods", {"source", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH periods_data AS (
+    SELECT
+        _ts_detect_periods(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            COALESCE(json_extract_string(to_json(params), '$.method'), 'fft')
+        ) AS _periods
+    FROM query_table(source::VARCHAR)
+)
 SELECT
-    _ts_detect_periods(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        COALESCE(json_extract_string(to_json(params), '$.method'), 'fft')
-    ) AS periods
-FROM query_table(source::VARCHAR)
+    (_periods).periods AS periods,
+    (_periods).n_periods AS n_periods,
+    (_periods).primary_period AS primary_period,
+    (_periods).method AS method
+FROM periods_data
 )"},
 
     // ts_detect_periods_by: Detect periods for grouped series
     // C++ API: ts_detect_periods_by(table_name, group_col, date_col, value_col, params)
     // params: method (default 'fft') - 'fft' or 'acf'
-    // Returns: TABLE(id, periods STRUCT)
+    // Returns: TABLE with id and expanded period columns
     {"ts_detect_periods_by", {"source", "group_col", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH periods_data AS (
+    SELECT
+        group_col AS id,
+        _ts_detect_periods(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            COALESCE(json_extract_string(to_json(params), '$.method'), 'fft')
+        ) AS _periods
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    _ts_detect_periods(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        COALESCE(json_extract_string(to_json(params), '$.method'), 'fft')
-    ) AS periods
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_periods).periods AS periods,
+    (_periods).n_periods AS n_periods,
+    (_periods).primary_period AS primary_period,
+    (_periods).method AS method
+FROM periods_data
 )"},
 
     // ts_detect_peaks_by: Detect peaks for grouped series
     // C++ API: ts_detect_peaks_by(table_name, group_col, date_col, value_col, params)
     // params: min_distance, min_prominence, smooth_first
-    // Returns: TABLE(id, peaks STRUCT)
+    // Returns: TABLE with id and expanded peak columns
     {"ts_detect_peaks_by", {"source", "group_col", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH peaks_data AS (
+    SELECT
+        group_col AS id,
+        ts_detect_peaks(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_distance') AS DOUBLE), 1.0),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_prominence') AS DOUBLE), 0.0),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.smooth_first') AS BOOLEAN), false)
+        ) AS _peaks
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    ts_detect_peaks(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_distance') AS DOUBLE), 1.0),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_prominence') AS DOUBLE), 0.0),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.smooth_first') AS BOOLEAN), false)
-    ) AS peaks
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_peaks).peaks AS peaks,
+    (_peaks).n_peaks AS n_peaks,
+    (_peaks).inter_peak_distances AS inter_peak_distances,
+    (_peaks).mean_period AS mean_period
+FROM peaks_data
 )"},
 
     // ts_detect_peaks: Detect peaks for a single series
     // C++ API: ts_detect_peaks(table_name, date_col, value_col, params)
     // params: min_distance, min_prominence, smooth_first
-    // Returns: TABLE(peaks STRUCT)
+    // Returns: TABLE with expanded peak columns
     {"ts_detect_peaks", {"source", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH peaks_data AS (
+    SELECT
+        ts_detect_peaks(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_distance') AS DOUBLE), 1.0),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_prominence') AS DOUBLE), 0.0),
+            COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.smooth_first') AS BOOLEAN), false)
+        ) AS _peaks
+    FROM query_table(source::VARCHAR)
+)
 SELECT
-    ts_detect_peaks(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_distance') AS DOUBLE), 1.0),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.min_prominence') AS DOUBLE), 0.0),
-        COALESCE(TRY_CAST(json_extract_string(to_json(params), '$.smooth_first') AS BOOLEAN), false)
-    ) AS peaks
-FROM query_table(source::VARCHAR)
+    (_peaks).peaks AS peaks,
+    (_peaks).n_peaks AS n_peaks,
+    (_peaks).inter_peak_distances AS inter_peak_distances,
+    (_peaks).mean_period AS mean_period
+FROM peaks_data
 )"},
 
     // ts_analyze_peak_timing_by: Analyze peak timing for grouped series
     // C++ API: ts_analyze_peak_timing_by(table_name, group_col, date_col, value_col, period, params)
-    // Returns: TABLE(id, timing STRUCT)
+    // Returns: TABLE with id and expanded timing columns
     {"ts_analyze_peak_timing_by", {"source", "group_col", "date_col", "value_col", "period", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH timing_data AS (
+    SELECT
+        group_col AS id,
+        ts_analyze_peak_timing(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            period::DOUBLE
+        ) AS _timing
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
 SELECT
-    group_col AS id,
-    ts_analyze_peak_timing(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        period::DOUBLE
-    ) AS timing
-FROM query_table(source::VARCHAR)
-GROUP BY group_col
+    id,
+    (_timing).n_peaks AS n_peaks,
+    (_timing).peak_times AS peak_times,
+    (_timing).variability_score AS variability_score,
+    (_timing).is_stable AS is_stable
+FROM timing_data
 )"},
 
     // ts_analyze_peak_timing: Analyze peak timing for a single series
     // C++ API: ts_analyze_peak_timing(table_name, date_col, value_col, period, params)
-    // Returns: TABLE(timing STRUCT)
+    // Returns: TABLE with expanded timing columns
     {"ts_analyze_peak_timing", {"source", "date_col", "value_col", "period", "params", nullptr}, {{nullptr, nullptr}},
 R"(
+WITH timing_data AS (
+    SELECT
+        ts_analyze_peak_timing(
+            LIST(value_col::DOUBLE ORDER BY date_col),
+            period::DOUBLE
+        ) AS _timing
+    FROM query_table(source::VARCHAR)
+)
 SELECT
-    ts_analyze_peak_timing(
-        LIST(value_col::DOUBLE ORDER BY date_col),
-        period::DOUBLE
-    ) AS timing
-FROM query_table(source::VARCHAR)
+    (_timing).n_peaks AS n_peaks,
+    (_timing).peak_times AS peak_times,
+    (_timing).variability_score AS variability_score,
+    (_timing).is_stable AS is_stable
+FROM timing_data
 )"},
 
     // ================================================================================

--- a/test/sql/extension_comparison.test
+++ b/test/sql/extension_comparison.test
@@ -36,12 +36,12 @@ FROM generate_series(0, 59) AS t(i);
 #######################################
 
 query I
-SELECT (stats).length FROM ts_stats('test_series', id, ds, value, '1 day') WHERE id = 'A';
+SELECT length FROM ts_stats('test_series', id, ds, value, '1 day') WHERE id = 'A';
 ----
 30
 
 query I
-SELECT round((stats).mean, 0) >= 17 FROM ts_stats('test_series', id, ds, value, '1 day') WHERE id = 'A';
+SELECT round(mean, 0) >= 17 FROM ts_stats('test_series', id, ds, value, '1 day') WHERE id = 'A';
 ----
 true
 

--- a/test/sql/ts_classify_seasonality.test
+++ b/test/sql/ts_classify_seasonality.test
@@ -191,21 +191,21 @@ SELECT COUNT(*) FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts
 ----
 2
 
-# Test table macro returns classification struct with is_seasonal field
+# Test table macro returns is_seasonal as column
 query I
-SELECT typeof((classification).is_seasonal) FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
+SELECT typeof(is_seasonal) FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
 ----
 BOOLEAN
 
-# Test table macro returns timing_classification
+# Test table macro returns timing_classification column
 query I
-SELECT (classification).timing_classification IS NOT NULL FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
+SELECT timing_classification IS NOT NULL FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
 ----
 true
 
-# Test table macro returns modulation_type
+# Test table macro returns modulation_type column
 query I
-SELECT (classification).modulation_type IS NOT NULL FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
+SELECT modulation_type IS NOT NULL FROM ts_classify_seasonality_by('grouped_seasonal', group_id, ts, val, 4) WHERE id = 'A';
 ----
 true
 
@@ -223,27 +223,27 @@ SELECT ('2024-01-01'::TIMESTAMP + INTERVAL (id - 1) DAY)::TIMESTAMP AS ts,
        [10.0, 20.0, 30.0, 40.0][(id - 1) % 4 + 1] AS val
 FROM generate_series(1, 16) AS t(id);
 
-# Test single-series macro returns a result
+# Test single-series macro returns timing_classification column
 query I
-SELECT (classification).timing_classification IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
+SELECT timing_classification IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
 ----
 true
 
-# Test single-series macro returns is_seasonal field
+# Test single-series macro returns is_seasonal column
 query I
-SELECT (classification).is_seasonal IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
+SELECT is_seasonal IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
 ----
 true
 
-# Test single-series macro returns modulation_type field
+# Test single-series macro returns modulation_type column
 query I
-SELECT (classification).modulation_type IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
+SELECT modulation_type IS NOT NULL FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
 ----
 true
 
-# Test single-series macro returns seasonal_strength field
+# Test single-series macro returns seasonal_strength column
 query I
-SELECT (classification).seasonal_strength >= 0 FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
+SELECT seasonal_strength >= 0 FROM ts_classify_seasonality('single_seasonal', ts, val, 4.0);
 ----
 true
 

--- a/test/sql/ts_features.test
+++ b/test/sql/ts_features.test
@@ -178,19 +178,19 @@ FROM generate_series(0, 9) AS t(i);
 
 # Test ts_features_table returns a result
 query I
-SELECT (features).mean IS NOT NULL FROM ts_features_table('test_single_series', date, value);
+SELECT mean IS NOT NULL FROM ts_features_table('test_single_series', date, value);
 ----
 true
 
 # Test ts_features_table mean calculation
 query I
-SELECT ABS((features).mean - 5.5) < 0.01 FROM ts_features_table('test_single_series', date, value);
+SELECT ABS(mean - 5.5) < 0.01 FROM ts_features_table('test_single_series', date, value);
 ----
 true
 
 # Test ts_features_table length
 query I
-SELECT (features).length = 10 FROM ts_features_table('test_single_series', date, value);
+SELECT length = 10 FROM ts_features_table('test_single_series', date, value);
 ----
 true
 
@@ -227,17 +227,17 @@ SELECT count(DISTINCT id) FROM ts_features_by('test_multi_series', id, date, val
 
 # Test ts_features_by mean per group
 query IR
-SELECT id, (features).mean FROM ts_features_by('test_multi_series', id, date, value) ORDER BY id;
+SELECT id, mean FROM ts_features_by('test_multi_series', id, date, value) ORDER BY id;
 ----
 A	5.5
 B	9.0
 
 # Test ts_features_by length per group
-query II
-SELECT id, (features).length FROM ts_features_by('test_multi_series', id, date, value) ORDER BY id;
+query IR
+SELECT id, length FROM ts_features_by('test_multi_series', id, date, value) ORDER BY id;
 ----
-A	10
-B	10
+A	10.0
+B	10.0
 
 statement ok
 DROP TABLE test_multi_series;

--- a/test/sql/ts_stats.test
+++ b/test/sql/ts_stats.test
@@ -25,21 +25,21 @@ FROM generate_series(0, 4) AS t(i);
 
 # Test basic ts_stats table function
 query II
-SELECT id, (stats).length FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
+SELECT id, length FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
 ----
 A	5
 B	5
 
 # Test mean calculation
 query IR
-SELECT id, (stats).mean FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
+SELECT id, mean FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
 ----
 A	3.0
 B	4.0
 
 # Test min/max
 query IRR
-SELECT id, (stats).min, (stats).max FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
+SELECT id, min, max FROM ts_stats('test_series', id, date, value, '1 day') ORDER BY id;
 ----
 A	1.0	5.0
 B	0.0	8.0

--- a/test/sql/ts_summary.test
+++ b/test/sql/ts_summary.test
@@ -31,7 +31,7 @@ FROM generate_series(0, 7) AS t(i);
 # Create stats table from test_series
 statement ok
 CREATE TABLE stats_table AS
-SELECT id, stats FROM ts_stats('test_series', id, date, value, '1 day');
+SELECT * FROM ts_stats('test_series', id, date, value, '1 day');
 
 #######################################
 # ts_stats_summary - Basic Tests
@@ -52,25 +52,25 @@ SELECT COUNT(*) AS n_series FROM stats_table;
 
 # Test min_length (B has 5 observations)
 query I
-SELECT MIN((stats).length) AS min_length FROM stats_table;
+SELECT MIN(length) AS min_length FROM stats_table;
 ----
 5
 
 # Test max_length (A has 10 observations)
 query I
-SELECT MAX((stats).length) AS max_length FROM stats_table;
+SELECT MAX(length) AS max_length FROM stats_table;
 ----
 10
 
 # Test avg_length (10 + 5 + 8) / 3 = 7.67
 query I
-SELECT AVG((stats).length) > 7 AND AVG((stats).length) < 8 FROM stats_table;
+SELECT AVG(length) > 7 AND AVG(length) < 8 FROM stats_table;
 ----
 true
 
 # Test total_nulls (no nulls in test data)
 query I
-SELECT SUM((stats).n_nulls) AS total_nulls FROM stats_table;
+SELECT SUM(n_nulls) AS total_nulls FROM stats_table;
 ----
 0
 
@@ -88,11 +88,11 @@ FROM generate_series(0, 9) AS t(i);
 
 statement ok
 CREATE TABLE stats_with_nulls AS
-SELECT id, stats FROM ts_stats('series_with_nulls', id, date, value, '1 day');
+SELECT * FROM ts_stats('series_with_nulls', id, date, value, '1 day');
 
 # Should report nulls
 query I
-SELECT SUM((stats).n_nulls) AS total_nulls FROM stats_with_nulls;
+SELECT SUM(n_nulls) AS total_nulls FROM stats_with_nulls;
 ----
 2
 
@@ -256,10 +256,10 @@ true
 query I
 SELECT
     COUNT(*) IS NOT NULL AND
-    AVG((stats).length) IS NOT NULL AND
-    MIN((stats).length) IS NOT NULL AND
-    MAX((stats).length) IS NOT NULL AND
-    SUM((stats).n_nulls) IS NOT NULL
+    AVG(length) IS NOT NULL AND
+    MIN(length) IS NOT NULL AND
+    MAX(length) IS NOT NULL AND
+    SUM(n_nulls) IS NOT NULL
 FROM stats_table;
 ----
 true

--- a/test/sql/ts_varchar_edge_cases.test
+++ b/test/sql/ts_varchar_edge_cases.test
@@ -48,7 +48,7 @@ SELECT COUNT(*) FROM ts_stats('varchar_data', id, ds, y, '1d');
 
 # Verify stats are computed correctly
 query I
-SELECT (stats).length FROM ts_stats('varchar_data', id, ds, y, '1d') WHERE id = 'A';
+SELECT length FROM ts_stats('varchar_data', id, ds, y, '1d') WHERE id = 'A';
 ----
 60
 


### PR DESCRIPTION
## Summary

- All `_by` table macros now return expanded columns instead of nested STRUCT columns
- Improves usability by allowing direct column access (e.g., `mean` instead of `(stats).mean`)
- Affected macros:
  - `ts_stats` / `ts_stats_by` (36 columns)
  - `ts_data_quality` / `ts_data_quality_by` (8 columns)
  - `ts_mstl_decomposition_by` (4 columns)
  - `ts_features_table` / `ts_features_by` (116 columns)
  - `ts_detect_periods` / `ts_detect_periods_by` (4 columns)
  - `ts_detect_peaks` / `ts_detect_peaks_by` (4 columns)
  - `ts_analyze_peak_timing` / `ts_analyze_peak_timing_by` (4 columns)
  - `ts_classify_seasonality` / `ts_classify_seasonality_by` (8 columns)

## Breaking Change

Users need to update queries from struct syntax to direct column access:

```sql
-- Before
SELECT id, (stats).mean, (stats).length FROM ts_stats_by(...);

-- After
SELECT id, mean, length FROM ts_stats_by(...);
```

## Test plan

- [x] All existing tests updated and passing
- [x] Manual verification of each updated macro
- [x] Documentation updated

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)