### PR TITLE
fix: Preserve input columns in ts_fill_nulls_*_by functions

### DIFF
--- a/test/sql/ts_imputation.test
+++ b/test/sql/ts_imputation.test
@@ -4,8 +4,6 @@
 
 require anofox_forecast
 
-require json
-
 #######################################
 # Setup Test Data
 #######################################
@@ -30,13 +28,13 @@ SELECT COUNT(*) FROM ts_fill_nulls_const_by('impute_test', id, date, val, 0.0);
 
 # Test no NULLs remain after fill
 query I
-SELECT COUNT(*) FROM ts_fill_nulls_const_by('impute_test', id, date, val, 0.0) WHERE value_col IS NULL;
+SELECT COUNT(*) FROM ts_fill_nulls_const_by('impute_test', id, date, val, 0.0) WHERE filled_value IS NULL;
 ----
 0
 
 # Verify filled values
 query R
-SELECT SUM(value_col) FROM ts_fill_nulls_const_by('impute_test', id, date, val, 0.0);
+SELECT SUM(filled_value) FROM ts_fill_nulls_const_by('impute_test', id, date, val, 0.0);
 ----
 9.0
 
@@ -52,13 +50,13 @@ SELECT COUNT(*) FROM ts_fill_nulls_forward_by('impute_test', id, date, val);
 
 # Test no NULLs remain after fill
 query I
-SELECT COUNT(*) FROM ts_fill_nulls_forward_by('impute_test', id, date, val) WHERE value_col IS NULL;
+SELECT COUNT(*) FROM ts_fill_nulls_forward_by('impute_test', id, date, val) WHERE filled_value IS NULL;
 ----
 0
 
 # Verify forward fill carries previous value
 query R
-SELECT value_col FROM ts_fill_nulls_forward_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
+SELECT filled_value FROM ts_fill_nulls_forward_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
 ----
 1.0
 
@@ -74,13 +72,13 @@ SELECT COUNT(*) FROM ts_fill_nulls_backward_by('impute_test', id, date, val);
 
 # Test no NULLs remain after fill
 query I
-SELECT COUNT(*) FROM ts_fill_nulls_backward_by('impute_test', id, date, val) WHERE value_col IS NULL;
+SELECT COUNT(*) FROM ts_fill_nulls_backward_by('impute_test', id, date, val) WHERE filled_value IS NULL;
 ----
 0
 
 # Verify backward fill uses next value
 query R
-SELECT value_col FROM ts_fill_nulls_backward_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
+SELECT filled_value FROM ts_fill_nulls_backward_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
 ----
 3.0
 
@@ -96,13 +94,13 @@ SELECT COUNT(*) FROM ts_fill_nulls_mean_by('impute_test', id, date, val);
 
 # Test no NULLs remain after fill
 query I
-SELECT COUNT(*) FROM ts_fill_nulls_mean_by('impute_test', id, date, val) WHERE value_col IS NULL;
+SELECT COUNT(*) FROM ts_fill_nulls_mean_by('impute_test', id, date, val) WHERE filled_value IS NULL;
 ----
 0
 
 # Verify mean fill uses series mean (mean of 1,3,5 = 3)
 query R
-SELECT value_col FROM ts_fill_nulls_mean_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
+SELECT filled_value FROM ts_fill_nulls_mean_by('impute_test', id, date, val) ORDER BY date LIMIT 1 OFFSET 1;
 ----
 3.0
 
@@ -119,6 +117,50 @@ SELECT
     (SELECT COUNT(*) FROM ts_fill_nulls_mean_by('impute_test', id, date, val));
 ----
 5	5	5	5
+
+#######################################
+# Column Preservation Tests
+#######################################
+
+# Create table with extra columns
+statement ok
+CREATE TABLE impute_extra AS
+SELECT 'A' AS id, '2023-01-01'::TIMESTAMP AS date, 1.0 AS val, 'x' AS extra_col, 100 AS num_col
+UNION ALL SELECT 'A', '2023-01-02', NULL, 'y', 200;
+
+# Test that extra columns are preserved by ts_fill_nulls_const_by
+query I
+SELECT COUNT(*) FROM ts_fill_nulls_const_by('impute_extra', id, date, val, 0.0) WHERE extra_col IS NOT NULL AND num_col IS NOT NULL;
+----
+2
+
+# Test that extra columns are preserved by ts_fill_nulls_forward_by
+query I
+SELECT COUNT(*) FROM ts_fill_nulls_forward_by('impute_extra', id, date, val) WHERE extra_col IS NOT NULL AND num_col IS NOT NULL;
+----
+2
+
+# Test that extra columns are preserved by ts_fill_nulls_backward_by
+query I
+SELECT COUNT(*) FROM ts_fill_nulls_backward_by('impute_extra', id, date, val) WHERE extra_col IS NOT NULL AND num_col IS NOT NULL;
+----
+2
+
+# Test that extra columns are preserved by ts_fill_nulls_mean_by
+query I
+SELECT COUNT(*) FROM ts_fill_nulls_mean_by('impute_extra', id, date, val) WHERE extra_col IS NOT NULL AND num_col IS NOT NULL;
+----
+2
+
+# Verify column values are preserved correctly
+query TI
+SELECT extra_col, num_col FROM ts_fill_nulls_const_by('impute_extra', id, date, val, 0.0) ORDER BY date;
+----
+x	100
+y	200
+
+statement ok
+DROP TABLE impute_extra;
 
 #######################################
 # Cleanup

--- a/test/sql/ts_type_preservation.test
+++ b/test/sql/ts_type_preservation.test
@@ -4,8 +4,6 @@
 
 require anofox_forecast
 
-require json
-
 #######################################
 # Setup Test Data with DATE type
 #######################################
@@ -101,30 +99,26 @@ SELECT typeof(date) FROM ts_drop_zeros_by('date_test', id, val) LIMIT 1;
 DATE
 
 #######################################
-# Functions using generate_series
-# Note: These functions always return TIMESTAMP because DuckDB's
-# generate_series returns TIMESTAMP and SQL type system is determined
-# at query planning time, not runtime. Cast to DATE if needed:
-# SELECT date_col::DATE FROM ts_fill_gaps_by(...)
+# Functions using generate_series (now preserve input type)
 #######################################
 
-# ts_fill_gaps - returns TIMESTAMP (generate_series limitation)
+# ts_fill_gaps - preserves input DATE type
 query T
-SELECT typeof(date_col) FROM ts_fill_gaps_by('date_test', id, date, val, '1d') LIMIT 1;
+SELECT typeof(date) FROM ts_fill_gaps_by('date_test', id, date, val, '1d') LIMIT 1;
 ----
-TIMESTAMP
+DATE
 
-# ts_fill_forward - returns TIMESTAMP (generate_series limitation)
+# ts_fill_forward - preserves input DATE type
 query T
-SELECT typeof(date_col) FROM ts_fill_forward_by('date_test', id, date, val, '2023-01-10', '1d') LIMIT 1;
+SELECT typeof(date) FROM ts_fill_forward_by('date_test', id, date, val, '2023-01-10', '1d') LIMIT 1;
 ----
-TIMESTAMP
+DATE
 
-# ts_fill_gaps_operator - returns TIMESTAMP (generate_series limitation)
+# ts_fill_gaps_operator - preserves input DATE type
 query T
-SELECT typeof(date_col) FROM ts_fill_gaps_by('date_test', id, date, val, '1d') LIMIT 1;
+SELECT typeof(date) FROM ts_fill_gaps_by('date_test', id, date, val, '1d') LIMIT 1;
 ----
-TIMESTAMP
+DATE
 
 #######################################
 # TIMESTAMP Input Tests
@@ -152,7 +146,7 @@ TIMESTAMP
 
 # generate_series functions output TIMESTAMP
 query T
-SELECT typeof(date_col) FROM ts_fill_gaps_by('timestamp_test', id, date, val, '1d') LIMIT 1;
+SELECT typeof(date) FROM ts_fill_gaps_by('timestamp_test', id, date, val, '1d') LIMIT 1;
 ----
 TIMESTAMP
 


### PR DESCRIPTION
## Summary
- Fixed `ts_fill_nulls_const_by`, `ts_fill_nulls_forward_by`, `ts_fill_nulls_backward_by`, and `ts_fill_nulls_mean_by` to preserve all input columns
- Filled values are now output as a new `filled_value` column (due to DuckDB macro limitations with EXCLUDE/REPLACE parameter substitution)
- Added column preservation tests to prevent regression

## Test plan
- [x] All existing imputation tests pass with updated column names
- [x] New column preservation tests verify extra columns are retained
- [x] Type preservation tests pass
- [x] Full test suite passes (106 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)