### PR TITLE
fix: ts_stats_by preserves column names and handles calendar frequencies (#147)

### DIFF
--- a/crates/anofox-fcst-core/src/lib.rs
+++ b/crates/anofox-fcst-core/src/lib.rs
@@ -95,4 +95,7 @@ pub use seasonality::{
     ChangeDetectionResult, ChangePointType, InstantaneousPeriodResult, SeasonalType,
     SeasonalityAnalysis, SeasonalityChangePoint, SeasonalityClassification, StrengthMethod,
 };
-pub use stats::{compute_ts_stats, compute_ts_stats_with_dates, TsStats};
+pub use stats::{
+    compute_ts_stats, compute_ts_stats_with_dates, compute_ts_stats_with_dates_and_type,
+    FrequencyType, TsStats,
+};

--- a/crates/anofox-fcst-ffi/src/types.rs
+++ b/crates/anofox-fcst-ffi/src/types.rs
@@ -102,6 +102,47 @@ pub enum DateType {
     Integer = 2,
 }
 
+/// Frequency type enumeration for calendar vs fixed frequencies.
+///
+/// Calendar frequencies (monthly, quarterly, yearly) have variable durations
+/// and require special handling for expected_length and gap detection.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FrequencyType {
+    /// Fixed duration frequencies (daily, hourly, weekly, etc.)
+    /// These have consistent microsecond durations.
+    #[default]
+    Fixed = 0,
+    /// Monthly frequency - variable duration (28-31 days)
+    Monthly = 1,
+    /// Quarterly frequency - variable duration (3 months)
+    Quarterly = 2,
+    /// Yearly frequency - variable duration (365 or 366 days)
+    Yearly = 3,
+}
+
+impl From<FrequencyType> for anofox_fcst_core::FrequencyType {
+    fn from(ftype: FrequencyType) -> Self {
+        match ftype {
+            FrequencyType::Fixed => Self::Fixed,
+            FrequencyType::Monthly => Self::Monthly,
+            FrequencyType::Quarterly => Self::Quarterly,
+            FrequencyType::Yearly => Self::Yearly,
+        }
+    }
+}
+
+impl From<anofox_fcst_core::FrequencyType> for FrequencyType {
+    fn from(ftype: anofox_fcst_core::FrequencyType) -> Self {
+        match ftype {
+            anofox_fcst_core::FrequencyType::Fixed => Self::Fixed,
+            anofox_fcst_core::FrequencyType::Monthly => Self::Monthly,
+            anofox_fcst_core::FrequencyType::Quarterly => Self::Quarterly,
+            anofox_fcst_core::FrequencyType::Yearly => Self::Yearly,
+        }
+    }
+}
+
 /// Date array supporting multiple date types.
 #[repr(C)]
 pub struct DateArray {

--- a/src/anofox_forecast_extension.cpp
+++ b/src/anofox_forecast_extension.cpp
@@ -17,6 +17,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     // Register EDA functions
     RegisterTsStatsFunction(loader);
+    RegisterTsStatsByFunction(loader);  // Native table function for ts_stats_by
     RegisterTsQualityReportFunction(loader);
     RegisterTsStatsSummaryFunction(loader);
 

--- a/src/include/anofox_fcst_ffi.h
+++ b/src/include/anofox_fcst_ffi.h
@@ -84,6 +84,32 @@ typedef enum ErrorCode {
 } ErrorCode;
 
 /**
+ * Frequency type enumeration for calendar vs fixed frequencies.
+ *
+ * Calendar frequencies (monthly, quarterly, yearly) have variable durations
+ * and require special handling for expected_length and gap detection.
+ */
+typedef enum FrequencyType {
+    /**
+     * Fixed duration frequencies (daily, hourly, weekly, etc.)
+     * These have consistent microsecond durations.
+     */
+    FIXED = 0,
+    /**
+     * Monthly frequency - variable duration (28-31 days)
+     */
+    MONTHLY = 1,
+    /**
+     * Quarterly frequency - variable duration (3 months)
+     */
+    QUARTERLY = 2,
+    /**
+     * Yearly frequency - variable duration (365 or 366 days)
+     */
+    YEARLY = 3,
+} FrequencyType;
+
+/**
  * Time series statistics result (34 metrics).
  */
 typedef struct TsStatsResult {
@@ -1521,6 +1547,25 @@ bool anofox_ts_stats_with_dates(const double *values,
                                 int64_t frequency_micros,
                                 struct TsStatsResult *out_result,
                                 struct AnofoxError *out_error);
+
+/**
+ * Compute time series statistics with date information and frequency type for gap detection.
+ *
+ * This version properly handles calendar frequencies (monthly, quarterly, yearly) which
+ * have variable durations that cannot be accurately represented in microseconds.
+ *
+ * # Safety
+ * All pointer arguments must be valid and non-null. Arrays must have the specified lengths.
+ * The dates array must have the same length as the values array.
+ */
+bool anofox_ts_stats_with_dates_and_type(const double *values,
+                                         const uint64_t *validity,
+                                         const int64_t *dates,
+                                         size_t length,
+                                         int64_t frequency_micros,
+                                         enum FrequencyType frequency_type,
+                                         struct TsStatsResult *out_result,
+                                         struct AnofoxError *out_error);
 
 /**
  * Mean Absolute Error

--- a/src/include/anofox_forecast_extension.hpp
+++ b/src/include/anofox_forecast_extension.hpp
@@ -6,6 +6,7 @@ namespace duckdb {
 
 // Forward declarations for function registration
 void RegisterTsStatsFunction(ExtensionLoader &loader);
+void RegisterTsStatsByFunction(ExtensionLoader &loader);
 void RegisterTsQualityReportFunction(ExtensionLoader &loader);
 void RegisterTsStatsSummaryFunction(ExtensionLoader &loader);
 void RegisterTsDataQualityFunction(ExtensionLoader &loader);

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -1545,61 +1545,21 @@ GROUP BY group_col
     // are now native table functions supporting arbitrary hierarchy levels.
     // See: ts_validate_separator.cpp, ts_aggregate_hierarchy.cpp, ts_combine_keys.cpp, ts_split_keys.cpp
 
-    // ts_stats_by: Alias for ts_stats (for API consistency with _by naming pattern)
+    // ts_stats_by: Compute time series statistics grouped by a unique ID column
     // C++ API: ts_stats_by(table_name, group_col, date_col, value_col, frequency)
-    // Returns: TABLE with expanded statistics columns
+    // Returns: TABLE with group column (preserving original name!) and 36 statistics columns
+    //
+    // This macro is a thin wrapper around the native streaming implementation (_ts_stats_by_native)
+    // which fixes the following bugs from issue #147:
+    // - Bug 1: Preserves the input group column name (was hardcoded as 'id')
+    // - Bug 2: Correctly calculates expected_length for monthly/quarterly/yearly frequencies
+    // - Bug 3: Correctly detects gaps for calendar frequencies
     {"ts_stats_by", {"source", "group_col", "date_col", "value_col", "frequency", nullptr}, {{nullptr, nullptr}},
 R"(
-WITH stats_data AS (
-    SELECT
-        group_col AS id,
-        _ts_stats_with_dates(
-            LIST(value_col::DOUBLE ORDER BY date_col),
-            LIST(date_col::TIMESTAMP ORDER BY date_col),
-            frequency::VARCHAR
-        ) AS _stats
-    FROM query_table(source::VARCHAR)
-    GROUP BY group_col
+SELECT * FROM _ts_stats_by_native(
+    (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR)),
+    frequency
 )
-SELECT
-    id,
-    (_stats).length AS length,
-    (_stats).n_nulls AS n_nulls,
-    (_stats).n_nan AS n_nan,
-    (_stats).n_zeros AS n_zeros,
-    (_stats).n_positive AS n_positive,
-    (_stats).n_negative AS n_negative,
-    (_stats).n_unique_values AS n_unique_values,
-    (_stats).is_constant AS is_constant,
-    (_stats).n_zeros_start AS n_zeros_start,
-    (_stats).n_zeros_end AS n_zeros_end,
-    (_stats).plateau_size AS plateau_size,
-    (_stats).plateau_size_nonzero AS plateau_size_nonzero,
-    (_stats).mean AS mean,
-    (_stats).median AS median,
-    (_stats).std_dev AS std_dev,
-    (_stats).variance AS variance,
-    (_stats).min AS min,
-    (_stats).max AS max,
-    (_stats).range AS range,
-    (_stats).sum AS sum,
-    (_stats).skewness AS skewness,
-    (_stats).kurtosis AS kurtosis,
-    (_stats).tail_index AS tail_index,
-    (_stats).bimodality_coef AS bimodality_coef,
-    (_stats).trimmed_mean AS trimmed_mean,
-    (_stats).coef_variation AS coef_variation,
-    (_stats).q1 AS q1,
-    (_stats).q3 AS q3,
-    (_stats).iqr AS iqr,
-    (_stats).autocorr_lag1 AS autocorr_lag1,
-    (_stats).trend_strength AS trend_strength,
-    (_stats).seasonality_strength AS seasonality_strength,
-    (_stats).entropy AS entropy,
-    (_stats).stability AS stability,
-    (_stats).expected_length AS expected_length,
-    (_stats).n_gaps AS n_gaps
-FROM stats_data
 )"},
 
     // ts_data_quality_by: Alias for ts_data_quality (for API consistency with _by naming pattern)

--- a/test/sql/ts_stats.test
+++ b/test/sql/ts_stats.test
@@ -139,7 +139,7 @@ SELECT _ts_stats(NULL) IS NULL;
 true
 
 #######################################
-# ts_stats_by - Alias Test
+# ts_stats_by - Native Table Function Tests (Issue #147)
 #######################################
 
 statement ok
@@ -150,14 +150,151 @@ SELECT
     (i % 10 + 1)::DOUBLE AS value
 FROM range(1, 21) t(i);
 
-# Test ts_stats_by alias works
+# Test ts_stats_by works
 query I
 SELECT count(*) FROM ts_stats_by('test_stats_by', group_id, date, value, '1d');
 ----
 2
 
+# Test column name is preserved (Issue #147 bug 1)
+# The first column should be named 'group_id', not 'id'
+# We verify this by selecting the column by name
+query T
+SELECT group_id FROM ts_stats_by('test_stats_by', group_id, date, value, '1d') ORDER BY group_id LIMIT 1;
+----
+A
+
 statement ok
 DROP TABLE test_stats_by;
+
+#######################################
+# ts_stats_by - Monthly Frequency Tests (Issue #147 bugs 2 & 3)
+#######################################
+
+# Create monthly data: Jan 2023 through Dec 2023 (12 months, no gaps)
+statement ok
+CREATE TABLE test_monthly_complete AS
+SELECT
+    'series_1' AS product_id,
+    ('2023-' || LPAD(CAST(i AS VARCHAR), 2, '0') || '-15')::TIMESTAMP AS date,
+    (100 + i * 10)::DOUBLE AS sales
+FROM generate_series(1, 12) AS t(i);
+
+# Test monthly expected_length - should be 12 (12 months from Jan to Dec)
+query II
+SELECT length, expected_length
+FROM ts_stats_by('test_monthly_complete', product_id, date, sales, '1mo');
+----
+12	12
+
+# Test monthly n_gaps - should be 0 (no missing months)
+query I
+SELECT n_gaps
+FROM ts_stats_by('test_monthly_complete', product_id, date, sales, '1mo');
+----
+0
+
+statement ok
+DROP TABLE test_monthly_complete;
+
+# Create monthly data with gaps: Jan, Feb, Mar, May, Jun (missing April)
+statement ok
+CREATE TABLE test_monthly_gaps AS
+SELECT
+    'series_1' AS product_id,
+    ('2023-' || LPAD(CAST(m AS VARCHAR), 2, '0') || '-15')::TIMESTAMP AS date,
+    (100 + m * 10)::DOUBLE AS sales
+FROM (VALUES (1), (2), (3), (5), (6)) AS t(m);
+
+# Test monthly expected_length with gaps - should be 6 (Jan to Jun = 6 months)
+query II
+SELECT length, expected_length
+FROM ts_stats_by('test_monthly_gaps', product_id, date, sales, '1mo');
+----
+5	6
+
+# Test monthly n_gaps - should be 1 (April is missing)
+query I
+SELECT n_gaps
+FROM ts_stats_by('test_monthly_gaps', product_id, date, sales, '1mo');
+----
+1
+
+statement ok
+DROP TABLE test_monthly_gaps;
+
+# Create quarterly data: Q1-Q4 2023 (4 quarters, no gaps)
+statement ok
+CREATE TABLE test_quarterly AS
+SELECT
+    'product_A' AS sku,
+    ('2023-' || LPAD(CAST((q-1) * 3 + 1 AS VARCHAR), 2, '0') || '-01')::TIMESTAMP AS quarter_start,
+    (1000 + q * 100)::DOUBLE AS revenue
+FROM generate_series(1, 4) AS t(q);
+
+# Test quarterly expected_length - should be 4
+query II
+SELECT length, expected_length
+FROM ts_stats_by('test_quarterly', sku, quarter_start, revenue, '1q');
+----
+4	4
+
+# Test quarterly n_gaps - should be 0
+query I
+SELECT n_gaps
+FROM ts_stats_by('test_quarterly', sku, quarter_start, revenue, '1q');
+----
+0
+
+statement ok
+DROP TABLE test_quarterly;
+
+# Create yearly data: 2020-2024 with 2022 missing (gap)
+statement ok
+CREATE TABLE test_yearly_gaps AS
+SELECT
+    'region_1' AS region,
+    (CAST(y AS VARCHAR) || '-06-15')::TIMESTAMP AS year_mid,
+    (50000 + (y - 2020) * 5000)::DOUBLE AS annual_sales
+FROM (VALUES (2020), (2021), (2023), (2024)) AS t(y);
+
+# Test yearly expected_length with gaps - should be 5 (2020 to 2024 = 5 years)
+query II
+SELECT length, expected_length
+FROM ts_stats_by('test_yearly_gaps', region, year_mid, annual_sales, '1y');
+----
+4	5
+
+# Test yearly n_gaps - should be 1 (2022 is missing)
+query I
+SELECT n_gaps
+FROM ts_stats_by('test_yearly_gaps', region, year_mid, annual_sales, '1y');
+----
+1
+
+statement ok
+DROP TABLE test_yearly_gaps;
+
+#######################################
+# ts_stats_by - Column Name Preservation with Different Names
+#######################################
+
+statement ok
+CREATE TABLE test_custom_cols AS
+SELECT
+    'SKU_' || i AS my_custom_product_name,
+    '2023-01-01'::TIMESTAMP + INTERVAL i DAY AS transaction_date,
+    (100 + i)::DOUBLE AS amount
+FROM generate_series(1, 5) AS t(i);
+
+# Verify the output column preserves the input name 'my_custom_product_name'
+query T
+SELECT my_custom_product_name FROM ts_stats_by('test_custom_cols', my_custom_product_name, transaction_date, amount, '1d') ORDER BY my_custom_product_name LIMIT 1;
+----
+SKU_1
+
+statement ok
+DROP TABLE test_custom_cols;
 
 
 #######################################


### PR DESCRIPTION
## Summary

- Fix **ID column name not preserved** - output now uses original input column name instead of hardcoded 'id'
- Fix **incorrect expected_length** for monthly/quarterly/yearly data - now uses calendar-based calculations
- Fix **incorrect n_gaps** for calendar frequencies - now uses calendar-aware gap detection

## Changes

### Rust Core (`crates/anofox-fcst-core/src/stats.rs`)
- Added `FrequencyType` enum (Fixed, Monthly, Quarterly, Yearly)
- Implemented calendar-aware calculation functions:
  - `compute_expected_months()` / `count_monthly_gaps()`
  - `compute_expected_quarters()` / `count_quarterly_gaps()`  
  - `compute_expected_years()` / `count_yearly_gaps()`

### Native Table Function (`src/table_functions/ts_stats.cpp`)
- Created `_ts_stats_by_native` streaming table function that:
  - Preserves input column names through the bind phase
  - Passes frequency type to Rust for calendar-aware calculations

### FFI Layer
- Added `FrequencyType` enum to FFI types
- Added `anofox_ts_stats_with_dates_and_type()` function

## Test plan

- [x] Verify column name preservation (`group_id` → `group_id`, not `id`)
- [x] Test monthly data: Jan-Dec (12 months) → `expected_length=12`, `n_gaps=0`
- [x] Test monthly with gap: Jan-Jun missing April → `expected_length=6`, `n_gaps=1`
- [x] Test yearly with gap: 2020-2024 missing 2022 → `expected_length=5`, `n_gaps=1`
- [x] All existing tests pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)