### PR TITLE
feat: add expected period validation with tolerance to ts_detect_periods

### DIFF
--- a/crates/anofox-fcst-core/src/lib.rs
+++ b/crates/anofox-fcst-core/src/lib.rs
@@ -79,10 +79,11 @@ pub use peaks::{
 };
 pub use periods::{
     aic_comparison, autoperiod, cfd_autoperiod, detect_multiple_periods_ts, detect_periods,
-    estimate_period_acf_ts, estimate_period_fft_ts, estimate_period_regression_ts, lomb_scargle,
-    matrix_profile_period, sazed_period, ssa_period, stl_period, AicPeriodResult, AutoperiodResult,
-    DetectedPeriod, LombScargleResult, MatrixProfilePeriodResult, MultiPeriodResult, PeriodMethod,
-    SazedPeriodResult, SinglePeriodResult, SsaPeriodResult, StlPeriodResult,
+    detect_periods_with_validation, estimate_period_acf_ts, estimate_period_fft_ts,
+    estimate_period_regression_ts, lomb_scargle, matrix_profile_period, sazed_period, ssa_period,
+    stl_period, AicPeriodResult, AutoperiodResult, DetectedPeriod, LombScargleResult,
+    MatrixProfilePeriodResult, MultiPeriodResult, PeriodMethod, SazedPeriodResult,
+    SinglePeriodResult, SsaPeriodResult, StlPeriodResult, DEFAULT_TOLERANCE,
 };
 pub use quality::{
     compute_data_quality, generate_quality_report, DataQuality, QualityReport, QualityThresholds,

--- a/crates/anofox-fcst-ffi/src/types.rs
+++ b/crates/anofox-fcst-ffi/src/types.rs
@@ -808,6 +808,12 @@ pub struct FlatMultiPeriodResult {
     pub phase_values: *mut c_double,
     /// Array of iteration values (1-indexed)
     pub iteration_values: *mut size_t,
+    /// Array of matches_expected flags
+    pub matches_expected_values: *mut bool,
+    /// Array of matched_expected_period values (NaN if no match)
+    pub matched_expected_values: *mut c_double,
+    /// Array of match_deviation values (NaN if no match)
+    pub match_deviation_values: *mut c_double,
     /// Number of detected periods
     pub n_periods: size_t,
     /// Primary (strongest) period
@@ -825,6 +831,9 @@ impl Default for FlatMultiPeriodResult {
             amplitude_values: std::ptr::null_mut(),
             phase_values: std::ptr::null_mut(),
             iteration_values: std::ptr::null_mut(),
+            matches_expected_values: std::ptr::null_mut(),
+            matched_expected_values: std::ptr::null_mut(),
+            match_deviation_values: std::ptr::null_mut(),
             n_periods: 0,
             primary_period: 0.0,
             method: [0; 32],

--- a/src/include/anofox_fcst_ffi.h
+++ b/src/include/anofox_fcst_ffi.h
@@ -383,6 +383,18 @@ typedef struct FlatMultiPeriodResult {
      */
     size_t *iteration_values;
     /**
+     * Array of matches_expected flags
+     */
+    bool *matches_expected_values;
+    /**
+     * Array of matched_expected_period values (NaN if no match)
+     */
+    double *matched_expected_values;
+    /**
+     * Array of match_deviation values (NaN if no match)
+     */
+    double *match_deviation_values;
+    /**
      * Number of detected periods
      */
     size_t n_periods;
@@ -1781,6 +1793,9 @@ bool anofox_ts_detect_periods(const double *values,
  * * `min_confidence` - Minimum confidence threshold; periods below this are filtered out.
  *   Use negative value (e.g., -1.0) to use method-specific default.
  *   Use 0.0 to disable filtering. Use positive value for custom threshold.
+ * * `expected_periods` - Optional array of expected periods to validate against (NULL = no validation)
+ * * `n_expected` - Number of expected periods (0 if expected_periods is NULL)
+ * * `tolerance` - Relative tolerance for matching (negative = use default 0.1)
  *
  * # Safety
  * All pointer arguments must be valid and non-null.
@@ -1790,6 +1805,9 @@ bool anofox_ts_detect_periods_flat(const double *values,
                                    const char *method,
                                    size_t max_period,
                                    double min_confidence,
+                                   const double *expected_periods,
+                                   size_t n_expected,
+                                   double tolerance,
                                    struct FlatMultiPeriodResult *out_result,
                                    struct AnofoxError *out_error);
 

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -1759,6 +1759,8 @@ FROM classification_data
     // params: method (default 'fft') - 'fft' or 'acf'
     //         max_period (default 365) - maximum period to search
     //         min_confidence (default: method-specific) - minimum confidence threshold
+    //         expected_periods (optional) - list of expected periods for validation
+    //         tolerance (default 0.1) - relative tolerance for period matching
     // Returns: TABLE with expanded period columns
     {"ts_detect_periods", {"source", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
@@ -1768,7 +1770,9 @@ WITH periods_data AS (
             LIST(value_col::DOUBLE ORDER BY date_col),
             COALESCE(json_extract_string(to_json(params), '$.method'), 'fft'),
             COALESCE(CAST(json_extract(to_json(params), '$.max_period') AS BIGINT), 0),
-            COALESCE(CAST(json_extract(to_json(params), '$.min_confidence') AS DOUBLE), -1.0)
+            COALESCE(CAST(json_extract(to_json(params), '$.min_confidence') AS DOUBLE), -1.0),
+            COALESCE(CAST(json_extract(to_json(params), '$.expected_periods') AS DOUBLE[]), NULL),
+            COALESCE(CAST(json_extract(to_json(params), '$.tolerance') AS DOUBLE), -1.0)
         ) AS _periods
     FROM query_table(source::VARCHAR)
 )
@@ -1786,6 +1790,8 @@ FROM periods_data
     //         max_period (default 365) - maximum period to search (suitable for daily data)
     //         min_confidence (default: method-specific) - minimum confidence threshold
     //                        Use 0 to disable filtering, positive value for custom threshold
+    //         expected_periods (optional) - list of expected periods for validation
+    //         tolerance (default 0.1) - relative tolerance for period matching
     // Returns: TABLE with id and expanded period columns
     {"ts_detect_periods_by", {"source", "group_col", "date_col", "value_col", "params", nullptr}, {{nullptr, nullptr}},
 R"(
@@ -1796,7 +1802,9 @@ WITH periods_data AS (
             LIST(value_col::DOUBLE ORDER BY date_col),
             COALESCE(json_extract_string(to_json(params), '$.method'), 'fft'),
             COALESCE(CAST(json_extract(to_json(params), '$.max_period') AS BIGINT), 0),
-            COALESCE(CAST(json_extract(to_json(params), '$.min_confidence') AS DOUBLE), -1.0)
+            COALESCE(CAST(json_extract(to_json(params), '$.min_confidence') AS DOUBLE), -1.0),
+            COALESCE(CAST(json_extract(to_json(params), '$.expected_periods') AS DOUBLE[]), NULL),
+            COALESCE(CAST(json_extract(to_json(params), '$.tolerance') AS DOUBLE), -1.0)
         ) AS _periods
     FROM query_table(source::VARCHAR)
     GROUP BY group_col


### PR DESCRIPTION
## Summary
- Add the ability to validate detected periods against user-specified expected periods with configurable tolerance
- A detected period `p` matches expected `e` if: `|p - e| / e <= tolerance` (default 0.1 = 10%)
- New API parameters: `expected_periods` (list) and `tolerance` (default 0.1)
- New output columns: `matches_expected`, `matched_expected_period`, `match_deviation`

## Test plan
- [x] Rust unit tests pass (23 tests including new validation tests)
- [x] All SQL tests pass (129 assertions)
- [x] Manual verification with synthetic data showing matching and non-matching cases

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)