### PR TITLE
fix: error on invalid model names instead of silent fallback to AutoETS

### DIFF
--- a/crates/anofox-fcst-ffi/src/lib.rs
+++ b/crates/anofox-fcst-ffi/src/lib.rs
@@ -3358,9 +3358,15 @@ pub unsafe extern "C" fn anofox_ts_forecast(
             .to_str()
             .unwrap_or("auto");
 
-        let model_type: anofox_fcst_core::ModelType = model_str
-            .parse()
-            .unwrap_or(anofox_fcst_core::ModelType::AutoETS);
+        let model_type: anofox_fcst_core::ModelType = match model_str.parse() {
+            Ok(m) => m,
+            Err(_) => {
+                return Err(anofox_fcst_core::ForecastError::InvalidModel(format!(
+                    "Unknown model: '{}'",
+                    model_str
+                )))
+            }
+        };
 
         // Parse ETS model spec (e.g., "AAA", "MNM", "AAdA")
         let ets_spec = CStr::from_ptr(opts.ets_model.as_ptr())
@@ -3561,9 +3567,15 @@ pub unsafe extern "C" fn anofox_ts_forecast_exog(
             .to_str()
             .unwrap_or("auto");
 
-        let model_type: anofox_fcst_core::ModelType = model_str
-            .parse()
-            .unwrap_or(anofox_fcst_core::ModelType::AutoETS);
+        let model_type: anofox_fcst_core::ModelType = match model_str.parse() {
+            Ok(m) => m,
+            Err(_) => {
+                return Err(anofox_fcst_core::ForecastError::InvalidModel(format!(
+                    "Unknown model: '{}'",
+                    model_str
+                )))
+            }
+        };
 
         // Parse ETS model spec (e.g., "AAA", "MNM", "AAdA")
         let ets_spec = CStr::from_ptr(opts.ets_model.as_ptr())

--- a/src/table_functions/ts_cv_forecast_native.cpp
+++ b/src/table_functions/ts_cv_forecast_native.cpp
@@ -539,6 +539,9 @@ static OperatorFinalizeResultType TsCvForecastNativeFinalize(
             );
 
             if (!success) {
+                if (error.code == INVALID_MODEL) {
+                    throw InvalidInputException(string(error.message));
+                }
                 // Skip this group on error
                 continue;
             }

--- a/src/table_functions/ts_forecast_native.cpp
+++ b/src/table_functions/ts_forecast_native.cpp
@@ -548,6 +548,9 @@ static OperatorFinalizeResultType TsForecastNativeFinalize(
             );
 
             if (!success) {
+                if (error.code == INVALID_MODEL) {
+                    throw InvalidInputException(string(error.message));
+                }
                 // Skip this group on error
                 continue;
             }

--- a/test/sql/ts_native_model_names.test
+++ b/test/sql/ts_native_model_names.test
@@ -422,6 +422,34 @@ WHERE split = 'test';
 true
 
 #######################################
+# Invalid model names should error
+#######################################
+
+statement error
+SELECT * FROM _ts_forecast_native(
+    (SELECT id, ds, y FROM model_name_data), 3, '1d', 'AIDA', MAP{});
+----
+Unknown model: 'AIDA'
+
+statement error
+SELECT * FROM _ts_cv_forecast_native(
+    (SELECT fold_id, split, id, ds, y FROM model_name_cv), 'AIDA', MAP{});
+----
+Unknown model: 'AIDA'
+
+statement error
+SELECT * FROM _ts_forecast_native(
+    (SELECT id, ds, y FROM model_name_data), 3, '1d', 'NotAModel', MAP{});
+----
+Unknown model: 'NotAModel'
+
+statement error
+SELECT * FROM _ts_cv_forecast_native(
+    (SELECT fold_id, split, id, ds, y FROM model_name_cv), 'NotAModel', MAP{});
+----
+Unknown model: 'NotAModel'
+
+#######################################
 # Cleanup
 #######################################
 


### PR DESCRIPTION
## Summary

Closes #166

- Invalid model names (e.g. `'AIDA'` instead of `'ADIDA'`) were silently falling back to AutoETS, returning wrong results with no indication of the typo
- Rust FFI now returns `ForecastError::InvalidModel` with the unrecognized name instead of `.unwrap_or(AutoETS)`
- C++ native table functions (`_ts_forecast_native`, `_ts_cv_forecast_native`) now throw `InvalidInputException` on `INVALID_MODEL` error code instead of silently skipping the group
- Added 4 test cases verifying both functions error on invalid model names (`'AIDA'`, `'NotAModel'`)

## Test plan

- [x] `cargo test -p anofox-fcst-core -p anofox-fcst-ffi` — Rust tests pass
- [x] `cmake --build build/release` — builds successfully
- [x] `unittest "test/sql/ts_native_model_names.test"` — 63/63 assertions pass (55 existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)