### PR TITLE
Register anofox_fcst_ prefix aliases for table macros

### DIFF
--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -1837,8 +1837,14 @@ static unique_ptr<CreateMacroInfo> CreateTableMacro(const TsTableMacro &macro_de
 
 void RegisterTsTableMacros(ExtensionLoader &loader) {
     for (idx_t i = 0; ts_table_macros[i].name != nullptr; i++) {
+        // Register the short name (e.g. ts_forecast_by)
         auto info = CreateTableMacro(ts_table_macros[i]);
         loader.RegisterFunction(*info);
+
+        // Register the prefixed alias (e.g. anofox_fcst_ts_forecast_by)
+        auto alias_info = CreateTableMacro(ts_table_macros[i]);
+        alias_info->name = "anofox_fcst_" + string(ts_table_macros[i].name);
+        loader.RegisterFunction(*alias_info);
     }
 }
 

--- a/test/sql/ts_table_macro_aliases.test
+++ b/test/sql/ts_table_macro_aliases.test
@@ -1,0 +1,75 @@
+# name: test/sql/ts_table_macro_aliases.test
+# description: Tests that anofox_fcst_ prefix aliases exist for all table macros
+# group: [sql]
+
+require anofox_forecast
+
+#######################################
+# Setup: Create test data
+#######################################
+
+statement ok
+CREATE TABLE test_data(id VARCHAR, date DATE, value DOUBLE);
+
+statement ok
+INSERT INTO test_data
+SELECT 'series1', DATE '2023-01-01' + INTERVAL (i) DAY, 100.0 + i
+FROM generate_series(0, 59) t(i);
+
+#######################################
+# Forecasting aliases
+#######################################
+
+# anofox_fcst_ts_forecast_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_forecast_by(test_data, id, date, value, 'Naive', 3);
+----
+3
+
+#######################################
+# Data preparation aliases
+#######################################
+
+# anofox_fcst_ts_fill_gaps_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_fill_gaps_by(test_data, id, date, value, '1d');
+----
+60
+
+# anofox_fcst_ts_fill_forward_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_fill_forward_by(test_data, id, date, value, '2023-03-10', '1d');
+----
+60
+
+# anofox_fcst_ts_fill_nulls_forward_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_fill_nulls_forward_by(test_data, id, date, value);
+----
+60
+
+# anofox_fcst_ts_diff_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_diff_by(test_data, id, date, value, 1);
+----
+60
+
+#######################################
+# Filtering aliases
+#######################################
+
+# anofox_fcst_ts_drop_short_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_drop_short_by(test_data, id, 100);
+----
+0
+
+#######################################
+# Stats aliases
+#######################################
+
+# anofox_fcst_ts_stats_by should work as alias
+query I
+SELECT count(*) FROM anofox_fcst_ts_stats_by(test_data, id, date, value, '1d');
+----
+1


### PR DESCRIPTION
## Summary

- Register `anofox_fcst_` prefixed aliases for all table macros, matching the dual-naming convention already used by scalar and aggregate functions
- Add test coverage for the new aliases

Closes #176
See also: DataZooDE/anofox-landingpage#1 (docs fix for the installation page)

## Context

Table macros (`ts_forecast_by`, `ts_fill_gaps_by`, etc.) were the only function tier missing the `anofox_fcst_` prefix aliases. Users following docs that used the prefixed form (e.g. `anofox_fcst_ts_forecast`) got "function does not exist" errors.

The fix is a 6-line change in `RegisterTsTableMacros` that re-registers each macro under the prefixed name.

## Test plan

- [x] New `ts_table_macro_aliases.test` verifies aliases for forecasting, data prep, filtering, and stats macros
- [x] Existing `ts_native_param_validation` tests still pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)