### PR TITLE
fix: catch AutoETS panic on constant series (#192)

### DIFF
--- a/test/sql/ts_forecast_auto.test
+++ b/test/sql/ts_forecast_auto.test
@@ -87,6 +87,18 @@ FROM trend_data;
 ----
 true
 
+# Test AutoETS with constant series does not panic (issue #192)
+query I
+SELECT length((_ts_forecast([42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0], 5, 'AutoETS')).point);
+----
+5
+
+# Test AutoETS constant series produces finite forecasts near the constant value
+query I
+SELECT ABS((_ts_forecast([42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0], 5, 'AutoETS')).point[1] - 42.0) < 1.0;
+----
+true
+
 # Test AutoETS confidence bounds
 query I
 SELECT (_ts_forecast([10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0], 3, 'AutoETS')).lower[1] <=


### PR DESCRIPTION
## Summary
- Wraps `forecast_auto_ets()` library calls in `catch_unwind()` so constant/near-zero-variance series that trigger NaN in the upstream optimizer (`ets.rs:801`) fall back to simplified ETS instead of panicking
- Series that were previously silently skipped (0 forecast rows) now produce valid forecasts via the fallback path
- Adds Rust unit test and SQL test for the constant-series edge case

## Test plan
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test` — new `test_forecast_auto_ets_constant_series` passes (30 values of 42.0 → 5 finite forecasts near 42.0)
- [x] `build/release/test/unittest "test/sql/*"` — all 1274 assertions pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)