### PR TITLE
fix: make frequency optional in ts_forecast_by (#191)

### DIFF
--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -487,7 +487,7 @@ FROM forecast_result
 )"},
 
     // ts_forecast_by: Generate forecasts per group (long format - one row per forecast step)
-    // C++ API: ts_forecast_by(table_name, group_col, date_col, target_col, method, horizon, frequency, params?)
+    // C++ API: ts_forecast_by(table_name, group_col, date_col, target_col, method, horizon, params?, frequency?)
     //
     // This macro is a thin wrapper around the native streaming implementation (_ts_forecast_native)
     // which uses significantly less memory than the previous SQL macro approach (GH#115).
@@ -497,7 +497,7 @@ FROM forecast_result
     //   Native:     ~35 MB peak memory (streaming)
     //
     // Supports both Polars-style ('1d', '1h', '30m', '1w', '1mo', '1q', '1y') and DuckDB INTERVAL ('1 day', '1 hour')
-    {"ts_forecast_by", {"source", "group_col", "date_col", "target_col", "method", "horizon", "frequency", nullptr}, {{"params", "MAP{}"}, {nullptr, nullptr}},
+    {"ts_forecast_by", {"source", "group_col", "date_col", "target_col", "method", "horizon", nullptr}, {{"params", "MAP{}"}, {"frequency", "'1d'"}, {nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_forecast_native(
     (SELECT group_col, date_col, target_col FROM query_table(source::VARCHAR)),

--- a/test/comparison/compare_extensions.py
+++ b/test/comparison/compare_extensions.py
@@ -125,11 +125,11 @@ TEST_CASES = [
 
     # ts_forecast_by - both extensions support table macro API (use uppercase model names)
     ("ts_forecast_by row count", """
-        SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3, NULL)
+        SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3)
     """),
 
     ("ts_forecast_by distinct steps", """
-        SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3, NULL)
+        SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3)
     """),
 ]
 

--- a/test/comparison/compare_structure.py
+++ b/test/comparison/compare_structure.py
@@ -129,11 +129,11 @@ def setup_test_data(conn: duckdb.DuckDBPyConnection):
 TEST_CASES = [
     # ts_forecast_by structure (long format) - use 'ARIMA' model (uppercase required by C++)
     ("ts_forecast_by columns",
-     "SELECT * FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3, NULL) LIMIT 1",
+     "SELECT * FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3) LIMIT 1",
      None),
 
     ("ts_forecast_by row count for 2 groups x 3 steps = 6",
-     "SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3, NULL)",
+     "SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'ARIMA', 3)",
      None),
 
     # Metrics - simple scalar returns (same in both)

--- a/test/sql/extension_comparison.test
+++ b/test/sql/extension_comparison.test
@@ -68,19 +68,19 @@ FROM (
 
 # Test ts_forecast_by returns long format with correct columns using MAP
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3);
 ----
 6
 
 # Test ts_forecast_by has forecast_step column
 query I
-SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3, '1d', MAP([], []));
+SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3);
 ----
 3
 
 # Test ts_forecast_by has id column
 query I
-SELECT COUNT(DISTINCT id) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3, '1d', MAP([], []));
+SELECT COUNT(DISTINCT id) FROM ts_forecast_by('test_series', id, ds, value, 'NAIVE', 3);
 ----
 2
 

--- a/test/sql/ts_conformal_coverage.test
+++ b/test/sql/ts_conformal_coverage.test
@@ -97,9 +97,7 @@ SELECT
     date,
     forecast_step,
     yhat AS forecast
-FROM ts_forecast_by(
-    'training_data', series_id, date, value, 'naive', 15, '1d'
-);
+FROM ts_forecast_by('training_data', series_id, date, value, 'naive', 15);
 
 # Verify we have forecasts for all series
 query I
@@ -155,9 +153,7 @@ SELECT
     date,
     forecast_step,
     yhat AS forecast
-FROM ts_forecast_by(
-    'train_plus_calib', series_id, date, value, 'naive', 15, '1d'
-);
+FROM ts_forecast_by('train_plus_calib', series_id, date, value, 'naive', 15);
 
 #######################################
 # Apply Conformal Intervals and Check Coverage (NAIVE)
@@ -214,9 +210,7 @@ SELECT
     date,
     forecast_step,
     yhat AS forecast
-FROM ts_forecast_by(
-    'training_data', series_id, date, value, 'snaive', 15, '1d', MAP{'period': '7'}
-);
+FROM ts_forecast_by('training_data', series_id, date, value, 'snaive', 15, MAP{'period': '7'});
 
 # Join forecasts with actuals for calibration
 statement ok
@@ -253,9 +247,7 @@ SELECT
     date,
     forecast_step,
     yhat AS forecast
-FROM ts_forecast_by(
-    'train_plus_calib', series_id, date, value, 'snaive', 15, '1d', MAP{'period': '7'}
-);
+FROM ts_forecast_by('train_plus_calib', series_id, date, value, 'snaive', 15, MAP{'period': '7'});
 
 #######################################
 # Apply Conformal Intervals and Check Coverage (SNAIVE)

--- a/test/sql/ts_forecast_by.test
+++ b/test/sql/ts_forecast_by.test
@@ -61,7 +61,7 @@ FROM generate_series(0, 59) AS t(i);
 
 # Test ts_forecast_by returns correct number of rows (2 groups x 5 steps = 10)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5);
 ----
 10
 
@@ -69,26 +69,26 @@ SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1
 query I
 SELECT COUNT(*) FROM (
     SELECT id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name, insample_fitted
-    FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
+    FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3)
 );
 ----
 6
 
 # Test forecast_step values are sequential (1 to horizon)
 query I
-SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 7, '1d', MAP([], []));
+SELECT COUNT(DISTINCT forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 7);
 ----
 7
 
 # Test all groups are represented
 query I
-SELECT COUNT(DISTINCT id) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []));
+SELECT COUNT(DISTINCT id) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3);
 ----
 2
 
 # Test dates are sequential after last observation
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3)
 WHERE ds > '2024-02-29'::TIMESTAMP;
 ----
 6
@@ -99,67 +99,67 @@ WHERE ds > '2024-02-29'::TIMESTAMP;
 
 # Naive - repeats last value
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3) LIMIT 1;
 ----
 Naive
 
 # SMA - Simple Moving Average
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SMA', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SMA', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SMA', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SMA', 3) LIMIT 1;
 ----
 SMA
 
 # SeasonalNaive - repeats seasonal pattern
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7) LIMIT 1;
 ----
 SeasonalNaive
 
 # SES - Simple Exponential Smoothing
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SES', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SES', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SES', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SES', 3) LIMIT 1;
 ----
 SES
 
 # SESOptimized - Optimized Simple Exponential Smoothing
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SESOptimized', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'SESOptimized', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SESOptimized', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'SESOptimized', 3) LIMIT 1;
 ----
 SESOptimized
 
 # RandomWalkDrift - Random walk with drift
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'RandomWalkDrift', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'RandomWalkDrift', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'RandomWalkDrift', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'RandomWalkDrift', 3) LIMIT 1;
 ----
 RandomWalkDrift
 
@@ -169,56 +169,56 @@ RandomWalkDrift
 
 # Holt - Double exponential smoothing (trend)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Holt', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Holt', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Holt', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Holt', 3) LIMIT 1;
 ----
 Holt
 
 # HoltWinters - Triple exponential smoothing (trend + seasonality)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7) LIMIT 1;
 ----
 HoltWinters
 
 # SeasonalES - Seasonal Exponential Smoothing
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalES', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalES', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalES', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalES', 7) LIMIT 1;
 ----
 SeasonalES
 
 # SeasonalESOptimized - Optimized Seasonal ES
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalESOptimized', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalESOptimized', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalESOptimized', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalESOptimized', 7) LIMIT 1;
 ----
 SeasonalESOptimized
 
 # SeasonalWindowAverage - Seasonal window average
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalWindowAverage', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalWindowAverage', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalWindowAverage', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalWindowAverage', 7) LIMIT 1;
 ----
 SeasonalWindowAverage
 
@@ -228,45 +228,45 @@ SeasonalWindowAverage
 
 # Theta - Basic Theta method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Theta', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Theta', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Theta', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'Theta', 3) LIMIT 1;
 ----
 Theta
 
 # OptimizedTheta - Optimized Theta method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'OptimizedTheta', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'OptimizedTheta', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'OptimizedTheta', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'OptimizedTheta', 3) LIMIT 1;
 ----
 OptimizedTheta
 
 # DynamicTheta - Dynamic Theta method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicTheta', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicTheta', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicTheta', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicTheta', 3) LIMIT 1;
 ----
 DynamicTheta
 
 # DynamicOptimizedTheta - Dynamic Optimized Theta method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicOptimizedTheta', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicOptimizedTheta', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicOptimizedTheta', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'DynamicOptimizedTheta', 3) LIMIT 1;
 ----
 DynamicOptimizedTheta
 
@@ -276,23 +276,23 @@ DynamicOptimizedTheta
 
 # ETS - Exponential smoothing state space
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 3) LIMIT 1;
 ----
 ETS
 
 # ARIMA - Autoregressive Integrated Moving Average
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ARIMA', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ARIMA', 3);
 ----
 6
 
 query I
-SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'ARIMA', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_groups', id, ds, value, 'ARIMA', 3) LIMIT 1;
 ----
 ARIMA
 
@@ -302,67 +302,67 @@ ARIMA
 
 # AutoETS - Automatic ETS selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoETS', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoETS', 3);
 ----
 6
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoETS', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoETS', 3) LIMIT 1;
 ----
 true
 
 # AutoARIMA - Automatic ARIMA selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoARIMA', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoARIMA', 3);
 ----
 6
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoARIMA', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoARIMA', 3) LIMIT 1;
 ----
 true
 
 # AutoTheta - Automatic Theta selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoTheta', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'AutoTheta', 3);
 ----
 6
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoTheta', 3, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_groups', id, ds, value, 'AutoTheta', 3) LIMIT 1;
 ----
 true
 
 # AutoMFLES - Automatic MFLES selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMFLES', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMFLES', 7);
 ----
 14
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMFLES', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMFLES', 7) LIMIT 1;
 ----
 true
 
 # AutoMSTL - Automatic MSTL selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMSTL', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMSTL', 7);
 ----
 14
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMSTL', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoMSTL', 7) LIMIT 1;
 ----
 true
 
 # AutoTBATS - Automatic TBATS selection
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoTBATS', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoTBATS', 7);
 ----
 14
 
 query I
-SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoTBATS', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name IS NOT NULL FROM ts_forecast_by('test_seasonal', id, ds, value, 'AutoTBATS', 7) LIMIT 1;
 ----
 true
 
@@ -372,67 +372,67 @@ true
 
 # CrostonClassic - Classic Croston's method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonClassic', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonClassic', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonClassic', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonClassic', 5) LIMIT 1;
 ----
 CrostonClassic
 
 # CrostonOptimized - Optimized Croston
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonOptimized', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonOptimized', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonOptimized', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonOptimized', 5) LIMIT 1;
 ----
 CrostonOptimized
 
 # CrostonSBA - Croston SBA (Syntetos-Boylan Approximation)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonSBA', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonSBA', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonSBA', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'CrostonSBA', 5) LIMIT 1;
 ----
 CrostonSBA
 
 # ADIDA - Aggregate-Disaggregate Intermittent Demand Approach
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'ADIDA', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'ADIDA', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'ADIDA', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'ADIDA', 5) LIMIT 1;
 ----
 ADIDA
 
 # IMAPA - Intermittent Multiple Aggregation Prediction Algorithm
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'IMAPA', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'IMAPA', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'IMAPA', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'IMAPA', 5) LIMIT 1;
 ----
 IMAPA
 
 # TSB - Teunter-Syntetos-Babai method
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'TSB', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_intermittent', id, ds, value, 'TSB', 5);
 ----
 10
 
 query I
-SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'TSB', 5, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_intermittent', id, ds, value, 'TSB', 5) LIMIT 1;
 ----
 TSB
 
@@ -442,34 +442,34 @@ TSB
 
 # MFLES - Multiple Frequency Local Level Seasonal
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'MFLES', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'MFLES', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'MFLES', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'MFLES', 7) LIMIT 1;
 ----
 MFLES
 
 # MSTL - Multiple Seasonal Trend using Loess
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'MSTL', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'MSTL', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'MSTL', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'MSTL', 7) LIMIT 1;
 ----
 MSTL
 
 # TBATS - Trigonometric Box-Cox ARMA Trend Seasonal
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'TBATS', 7, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'TBATS', 7);
 ----
 14
 
 query I
-SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'TBATS', 7, '1d', MAP([], [])) LIMIT 1;
+SELECT model_name FROM ts_forecast_by('test_seasonal', id, ds, value, 'TBATS', 7) LIMIT 1;
 ----
 TBATS
 
@@ -479,20 +479,19 @@ TBATS
 
 # Test confidence_level parameter
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP(['confidence_level'], [0.80]));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, MAP(['confidence_level'], [0.80]));
 ----
 6
 
 # Test seasonal_period parameter
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7, '1d', MAP(['seasonal_period'], [7]));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'SeasonalNaive', 7, MAP(['seasonal_period'], [7]));
 ----
 14
 
 # Test multiple parameters
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7, '1d',
-    MAP(['confidence_level', 'seasonal_period'], [0.95, 7]));
+SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters', 7, MAP(['confidence_level', 'seasonal_period'], [0.95, 7]));
 ----
 14
 
@@ -502,19 +501,19 @@ SELECT COUNT(*) FROM ts_forecast_by('test_seasonal', id, ds, value, 'HoltWinters
 
 # Test with Polars-style frequency '1d'
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3);
 ----
 6
 
 # Test with DuckDB INTERVAL style '1 day'
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1 day', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, frequency := '1 day');
 ----
 6
 
 # Test with weekly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1w', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, frequency := '1w');
 ----
 6
 
@@ -524,32 +523,32 @@ SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1
 
 # Test point forecast is numeric and not NULL
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3)
 WHERE yhat IS NOT NULL;
 ----
 6
 
 # Test confidence bounds are valid (lower <= point <= upper)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3)
 WHERE yhat_lower <= yhat AND yhat <= yhat_upper;
 ----
 6
 
 # Test forecast steps are correct
 query I
-SELECT MIN(forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1d', MAP([], []));
+SELECT MIN(forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5);
 ----
 1
 
 query I
-SELECT MAX(forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1d', MAP([], []));
+SELECT MAX(forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5);
 ----
 5
 
 # Test insample_fitted is returned as array
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3)
 WHERE insample_fitted IS NOT NULL;
 ----
 6
@@ -560,13 +559,13 @@ WHERE insample_fitted IS NOT NULL;
 
 # Forecast horizon of 1
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 1, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 1);
 ----
 2
 
 # Large forecast horizon
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 30, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 30);
 ----
 60
 
@@ -577,19 +576,19 @@ SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 30, '
 
 # Test MAP with ETS model parameter
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 5, '1d', MAP{'model': 'AAA'});
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 5, MAP{'model': 'AAA'});
 ----
 10
 
 # Test empty params - use MAP{} syntax (empty STRUCT {} not valid in DuckDB)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1d', MAP{});
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5);
 ----
 10
 
 # Test backward compatibility: MAP syntax still works
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 5, '1d', MAP{'model': 'AAA'});
+SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'ETS', 5, MAP{'model': 'AAA'});
 ----
 10
 

--- a/test/sql/ts_forecast_ets_model.test
+++ b/test/sql/ts_forecast_ets_model.test
@@ -31,13 +31,13 @@ FROM generate_series(0, 83) AS t(i);
 
 # Test: ETS without model parameter uses simplified fallback
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{});
+SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7);
 ----
 14
 
 # Test: ETS returns valid forecasts by default
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{})
+SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7)
 WHERE yhat IS NOT NULL AND yhat > 0;
 ----
 14
@@ -49,13 +49,13 @@ WHERE yhat IS NOT NULL AND yhat > 0;
 
 # Test: ETS with explicit model='AAA'
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': 'AAA'});
+SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': 'AAA'});
 ----
 14
 
 # Test: ETS with model='ANN'
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': 'ANN'});
+SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': 'ANN'});
 ----
 14
 
@@ -65,13 +65,13 @@ SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', M
 
 # Test: Invalid model spec returns error
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': 'XYZ'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': 'XYZ'});
 ----
 Invalid ETS model specification
 
 # Test: Invalid model spec with wrong characters
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': '123'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': '123'});
 ----
 Invalid ETS model specification
 
@@ -81,13 +81,13 @@ Invalid ETS model specification
 
 # Test: MAA (Multiplicative error, Additive trend, Additive seasonal) is unstable - rejected
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': 'MAA'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': 'MAA'});
 ----
 unstable
 
 # Test: MAdA (Multiplicative error, Additive damped trend, Additive seasonal) is unstable - rejected
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'model': 'MAdA'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'model': 'MAdA'});
 ----
 unstable
 
@@ -97,20 +97,19 @@ unstable
 
 # Test: 'model' param is only valid with ETS method
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'Naive', 7, '1d', MAP{'model': 'AAA'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'Naive', 7, MAP{'model': 'AAA'});
 ----
 only valid when method='ETS'
 
 # Test: Unknown parameter key gives error
 statement error
-SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d', MAP{'methd': 'AAA'});
+SELECT * FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'methd': 'AAA'});
 ----
 Unknown parameter
 
 # Test: model parameter with confidence_level (no model spec)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, '1d',
-    MAP{'confidence_level': '0.95'});
+SELECT COUNT(*) FROM ts_forecast_by('test_ets', id, ds, value, 'ETS', 7, MAP{'confidence_level': '0.95'});
 ----
 14
 

--- a/test/sql/ts_forecast_params.test
+++ b/test/sql/ts_forecast_params.test
@@ -160,26 +160,25 @@ true
 
 # MAP with confidence_level should not error (syntax accepted)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1d', MAP(['confidence_level'], [0.80]));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, MAP(['confidence_level'], [0.80]));
 ----
 6
 
 # MAP with seasonal_period should not error (syntax accepted)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'SeasonalNaive', 3, '1d', MAP(['seasonal_period'], [7]));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'SeasonalNaive', 3, MAP(['seasonal_period'], [7]));
 ----
 6
 
 # MAP with multiple parameters should not error (syntax accepted)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'HoltWinters', 3, '1d',
-    MAP(['confidence_level', 'seasonal_period'], [0.95, 7]));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'HoltWinters', 3, MAP(['confidence_level', 'seasonal_period'], [0.95, 7]));
 ----
 6
 
 # Empty MAP should work
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3);
 ----
 6
 
@@ -213,49 +212,49 @@ SELECT COUNT(*) FROM (
 
 # Polars-style '1d' frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3);
 ----
 6
 
 # DuckDB INTERVAL style '1 day'
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1 day', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1 day');
 ----
 6
 
 # Weekly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1w', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1w');
 ----
 6
 
 # Hourly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1h', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1h');
 ----
 6
 
 # Minute frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '30m', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '30m');
 ----
 6
 
 # Monthly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1mo', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1mo');
 ----
 6
 
 # Quarterly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1q', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1q');
 ----
 6
 
 # Yearly frequency
 query I
-SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, '1y', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('grouped_data', id, ds, value, 'Naive', 3, frequency := '1y');
 ----
 6
 

--- a/test/sql/ts_integer_frequency.test
+++ b/test/sql/ts_integer_frequency.test
@@ -122,19 +122,19 @@ SELECT COUNT(*) FROM ts_fill_gaps_by('freq_test', id, date, val, 1);
 
 # Polars-style frequency works
 query I
-SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2, '1d', MAP{});
+SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2);
 ----
 2
 
 # DuckDB INTERVAL style works
 query I
-SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2, '1 day', MAP{});
+SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2, frequency := '1 day');
 ----
 2
 
 # Integer frequency works (interpreted as days)
 query I
-SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2, 1, MAP{});
+SELECT COUNT(*) FROM ts_forecast_by('freq_test', id, date, val, 'naive', 2, frequency := 1);
 ----
 2
 

--- a/test/sql/ts_parallel_correctness.test
+++ b/test/sql/ts_parallel_correctness.test
@@ -33,7 +33,7 @@ SELECT COUNT(*), COUNT(DISTINCT unique_id) FROM parallel_test_data;
 statement ok
 CREATE TABLE forecast_parallel AS
 SELECT unique_id, ds, yhat, model_name
-FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'Naive', 7, '1d', MAP{})
+FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'Naive', 7)
 ORDER BY unique_id, ds;
 
 # Run with single thread
@@ -43,7 +43,7 @@ SET threads=1;
 statement ok
 CREATE TABLE forecast_single AS
 SELECT unique_id, ds, yhat, model_name
-FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'Naive', 7, '1d', MAP{})
+FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'Naive', 7)
 ORDER BY unique_id, ds;
 
 # Reset threads
@@ -251,7 +251,7 @@ SELECT COUNT(*), COUNT(DISTINCT unique_id) FROM stress_test_data;
 statement ok
 CREATE TABLE stress_forecast AS
 SELECT unique_id, ds, yhat
-FROM ts_forecast_by('stress_test_data', unique_id, ds, y, 'Naive', 14, '1d', MAP{});
+FROM ts_forecast_by('stress_test_data', unique_id, ds, y, 'Naive', 14);
 
 # Verify we got expected number of forecast rows (100 series × 14 horizon)
 query I
@@ -286,13 +286,13 @@ SELECT COUNT(*) FROM stress_forecast WHERE yhat < 0;
 statement ok
 CREATE TABLE hash_test_1 AS
 SELECT md5(CAST(unique_id AS VARCHAR) || CAST(ds AS VARCHAR) || CAST(ROUND(yhat, 8) AS VARCHAR)) as row_hash
-FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'SES', 7, '1d', MAP{})
+FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'SES', 7)
 ORDER BY unique_id, ds;
 
 statement ok
 CREATE TABLE hash_test_2 AS
 SELECT md5(CAST(unique_id AS VARCHAR) || CAST(ds AS VARCHAR) || CAST(ROUND(yhat, 8) AS VARCHAR)) as row_hash
-FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'SES', 7, '1d', MAP{})
+FROM ts_forecast_by('parallel_test_data', unique_id, ds, y, 'SES', 7)
 ORDER BY unique_id, ds;
 
 # Verify hashes match between runs

--- a/test/sql/ts_table_macro_aliases.test
+++ b/test/sql/ts_table_macro_aliases.test
@@ -22,7 +22,7 @@ FROM generate_series(0, 59) t(i);
 
 # anofox_fcst_ts_forecast_by should work as alias
 query I
-SELECT count(*) FROM anofox_fcst_ts_forecast_by(test_data, id, date, value, 'Naive', 3, '1d');
+SELECT count(*) FROM anofox_fcst_ts_forecast_by(test_data, id, date, value, 'Naive', 3);
 ----
 3
 

--- a/test/sql/ts_varchar_edge_cases.test
+++ b/test/sql/ts_varchar_edge_cases.test
@@ -58,13 +58,13 @@ SELECT length FROM ts_stats('varchar_data', id, ds, y, '1d') WHERE id = 'A';
 
 # ts_forecast_by should work with VARCHAR target columns
 query I
-SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 5);
 ----
 10
 
 # Verify forecasts are numeric
 query I
-SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 3, '1d', MAP([], []))
+SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 3)
 WHERE yhat IS NOT NULL AND typeof(yhat) = 'DOUBLE';
 ----
 6
@@ -153,7 +153,7 @@ true
 # Test with integer-like string for horizon in ts_forecast_by
 # This ensures the macro handles parameter type variations
 query I
-SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 5, '1d', MAP([], []));
+SELECT COUNT(*) FROM ts_forecast_by('varchar_data', id, ds, y, 'Naive', 5);
 ----
 10
 


### PR DESCRIPTION
## Summary
- Makes `frequency` an optional named parameter (default `'1d'`) in the `ts_forecast_by` macro, so `params` can be passed directly as the 7th argument
- Fixes the Binder Error users hit when following the quickstart/README example which omitted the `frequency` argument
- Updates ~125 test calls across 9 SQL test files and 2 Python comparison tests to use the new signature

**Before (broken):**
```sql
SELECT * FROM ts_forecast_by('m5_train', item_id, ds, y, 'SeasonalNaive', 28, {'seasonal_period': 7})
-- Binder Error: No function matches the given name and argument types
```

**After (works):**
```sql
-- Params as optional 7th arg, frequency defaults to '1d'
SELECT * FROM ts_forecast_by('m5_train', item_id, ds, y, 'SeasonalNaive', 28, {'seasonal_period': 7})

-- Explicit frequency via named parameter
SELECT * FROM ts_forecast_by('m5_train', item_id, ds, y, 'Naive', 28, frequency := '1w')
```

Closes #191

## Test plan
- [x] `cmake --build build/release` compiles cleanly
- [x] `build/release/test/unittest "test/sql/*"` — all 1274 assertions pass
- [x] `cargo test` — all Rust tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)