### PR TITLE
chore: update anofox-forecast crate to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750f8a1fe8a49ad89c42301dcc073c8203680fbbafdc260dbaaedc73970b55d6"
+checksum = "0222ebf10d82c1a31ab8263057258cf6a27c4afb908006ccef2c5bd2537ae5be"
 dependencies = [
  "anofox-regression 0.5.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = "0.4.2"
+anofox-forecast = "0.4.4"
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Update `anofox-forecast` dependency from `0.4.2` to `0.4.4`.

### v0.4.3 — AutoETS/AutoTheta seasonality fix
- Fix DSTM/DOTM missing seasonal config in AutoTheta (always created non-seasonal models)
- Fix ETS information criteria: add sigma² to param count, align sample size with actual residuals — prevents systematic penalization of seasonal models
- Expand ETS optimizer multi-start from 3 to 6 (alpha, gamma) combinations
- Lower ACF seasonal test threshold from z_95 to z_90 when user provides `seasonal_period`

### v0.4.4 — Nelder-Mead optimizer performance
- Contiguous flat simplex buffer (eliminates n+2 heap allocations per optimization)
- Squared-distance convergence with short-circuit (skip sqrt)
- Reduce allocations: residuals slice ref, `Cow<TimeSeries>` in AutoETS, vector reuse
- **4-12% faster** on AutoETS paths

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test` — all Rust tests pass
- [x] `cmake --build build/release` succeeds
- [x] `build/release/test/unittest "test/sql/*"` — all 62 SQL tests pass (1274 assertions)

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)