### PR TITLE
feat: add FunctionDescription metadata to all 281 registered functions

### DIFF
--- a/src/aggregate_functions/ts_changepoints_agg.cpp
+++ b/src/aggregate_functions/ts_changepoints_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 namespace duckdb {
 
@@ -257,12 +259,33 @@ void RegisterTsDetectChangepointsAggFunction(ExtensionLoader &loader) {
 
     AggregateFunctionSet func_set("ts_detect_changepoints_agg");
     func_set.AddFunction(agg_func);
-    loader.RegisterFunction(func_set);
+    {
+        CreateAggregateFunctionInfo info(func_set);
+        FunctionDescription desc;
+        desc.description = "Aggregate function: detects structural changepoints in time series for each group using Bayesian Online Changepoint Detection (BOCPD).";
+        desc.examples = {"SELECT product_id, ts_detect_changepoints_agg(date, value, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "changepoint-detection"};
+        desc.parameter_names = {"date", "value", "params"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::MAP(LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register with anofox_fcst_ prefix
     AggregateFunctionSet alias_set("anofox_fcst_ts_detect_changepoints_agg");
     alias_set.AddFunction(agg_func);
-    loader.RegisterFunction(alias_set);
+    {
+        CreateAggregateFunctionInfo info(alias_set);
+        info.alias_of = "ts_detect_changepoints_agg";
+        FunctionDescription desc;
+        desc.description = "Aggregate function: detects structural changepoints in time series for each group using Bayesian Online Changepoint Detection (BOCPD).";
+        desc.examples = {"SELECT product_id, anofox_fcst_ts_detect_changepoints_agg(date, value, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "changepoint-detection"};
+        desc.parameter_names = {"date", "value", "params"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::MAP(LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_classify_seasonality_agg.cpp
+++ b/src/aggregate_functions/ts_classify_seasonality_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 namespace duckdb {
 
@@ -319,12 +321,33 @@ void RegisterTsClassifySeasonalityAggFunction(ExtensionLoader &loader) {
 
     AggregateFunctionSet agg_set("ts_classify_seasonality_agg");
     agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(agg_set);
+    {
+        CreateAggregateFunctionInfo info(agg_set);
+        FunctionDescription desc;
+        desc.description = "Aggregate function: classifies the seasonality type (none, additive, multiplicative) for each group.";
+        desc.examples = {"SELECT product_id, ts_classify_seasonality_agg(date, value, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"date", "value", "period"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register with anofox_ prefix
     AggregateFunctionSet anofox_agg_set("anofox_fcst_ts_classify_seasonality_agg");
     anofox_agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(anofox_agg_set);
+    {
+        CreateAggregateFunctionInfo info(anofox_agg_set);
+        info.alias_of = "ts_classify_seasonality_agg";
+        FunctionDescription desc;
+        desc.description = "Aggregate function: classifies the seasonality type (none, additive, multiplicative) for each group.";
+        desc.examples = {"SELECT product_id, anofox_fcst_ts_classify_seasonality_agg(date, value, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"date", "value", "period"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_data_quality_agg.cpp
+++ b/src/aggregate_functions/ts_data_quality_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 namespace duckdb {
 
@@ -236,12 +238,33 @@ void RegisterTsDataQualityAggFunction(ExtensionLoader &loader) {
     // Register ts_data_quality_agg
     AggregateFunctionSet ts_dq_agg_set("ts_data_quality_agg");
     ts_dq_agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(ts_dq_agg_set);
+    {
+        CreateAggregateFunctionInfo info(ts_dq_agg_set);
+        FunctionDescription desc;
+        desc.description = "Aggregate function: assesses time series data quality for each group, reporting null counts, gap counts, duplicates, and quality score.";
+        desc.examples = {"SELECT product_id, ts_data_quality_agg(date, value) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "data-quality"};
+        desc.parameter_names = {"date", "value"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register anofox_fcst_ts_data_quality_agg alias
     AggregateFunctionSet anofox_dq_agg_set("anofox_fcst_ts_data_quality_agg");
     anofox_dq_agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(anofox_dq_agg_set);
+    {
+        CreateAggregateFunctionInfo info(anofox_dq_agg_set);
+        info.alias_of = "ts_data_quality_agg";
+        FunctionDescription desc;
+        desc.description = "Aggregate function: assesses time series data quality for each group, reporting null counts, gap counts, duplicates, and quality score.";
+        desc.examples = {"SELECT product_id, anofox_fcst_ts_data_quality_agg(date, value) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "data-quality"};
+        desc.parameter_names = {"date", "value"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_detect_periods_agg.cpp
+++ b/src/aggregate_functions/ts_detect_periods_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 namespace duckdb {
 
@@ -357,13 +359,56 @@ void RegisterTsDetectPeriodsAggFunction(ExtensionLoader &loader) {
     AggregateFunctionSet agg_set("ts_detect_periods_agg");
     agg_set.AddFunction(agg_func_2);
     agg_set.AddFunction(agg_func_3);
-    loader.RegisterFunction(agg_set);
+    {
+        CreateAggregateFunctionInfo info(agg_set);
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: detects seasonal periods for each group, returning the primary period, confidence, and a ranked list of candidates.";
+            desc.examples = {"SELECT product_id, ts_detect_periods_agg(date, value) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "period-detection"};
+            desc.parameter_names = {"date", "value"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: detects seasonal periods for each group, returning the primary period, confidence, and a ranked list of candidates.";
+            desc.examples = {"SELECT product_id, ts_detect_periods_agg(date, value, MAP{'method': 'auto'}) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "period-detection"};
+            desc.parameter_names = {"date", "value", "method"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register with anofox_ prefix
     AggregateFunctionSet anofox_agg_set("anofox_fcst_ts_detect_periods_agg");
     anofox_agg_set.AddFunction(agg_func_2);
     anofox_agg_set.AddFunction(agg_func_3);
-    loader.RegisterFunction(anofox_agg_set);
+    {
+        CreateAggregateFunctionInfo info(anofox_agg_set);
+        info.alias_of = "ts_detect_periods_agg";
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: detects seasonal periods for each group, returning the primary period, confidence, and a ranked list of candidates.";
+            desc.examples = {"SELECT product_id, anofox_fcst_ts_detect_periods_agg(date, value) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "period-detection"};
+            desc.parameter_names = {"date", "value"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: detects seasonal periods for each group, returning the primary period, confidence, and a ranked list of candidates.";
+            desc.examples = {"SELECT product_id, anofox_fcst_ts_detect_periods_agg(date, value, MAP{'method': 'auto'}) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "period-detection"};
+            desc.parameter_names = {"date", "value", "method"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_features_agg.cpp
+++ b/src/aggregate_functions/ts_features_agg.cpp
@@ -5,6 +5,8 @@
 #include "duckdb/common/printer.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include <unordered_map>
 #include <unordered_set>
 #include <limits>
@@ -425,21 +427,112 @@ void RegisterTsFeaturesAggFunction(ExtensionLoader &loader) {
     ts_features_set.AddFunction(agg_func_2);
     ts_features_set.AddFunction(agg_func_3);
     ts_features_set.AddFunction(agg_func_4);
-    loader.RegisterFunction(ts_features_set);
+    {
+        CreateAggregateFunctionInfo info(ts_features_set);
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features(date, value) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features(date, value, ['mean', 'std_dev']) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features(date, value, ['mean'], NULL) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection", "feature_params"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)), LogicalType::LIST(param_struct_type)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register ts_features_agg alias (for API consistency with ts_forecast_agg pattern)
     AggregateFunctionSet ts_features_agg_set("ts_features_agg");
     ts_features_agg_set.AddFunction(agg_func_2);
     ts_features_agg_set.AddFunction(agg_func_3);
     ts_features_agg_set.AddFunction(agg_func_4);
-    loader.RegisterFunction(ts_features_agg_set);
+    {
+        CreateAggregateFunctionInfo info(ts_features_agg_set);
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features_agg(date, value) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features_agg(date, value, config) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, ts_features_agg(date, value, ['mean'], NULL) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection", "feature_params"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)), LogicalType::LIST(param_struct_type)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register anofox_fcst_ts_features_agg alias (prefixed form)
     AggregateFunctionSet anofox_features_agg_set("anofox_fcst_ts_features_agg");
     anofox_features_agg_set.AddFunction(agg_func_2);
     anofox_features_agg_set.AddFunction(agg_func_3);
     anofox_features_agg_set.AddFunction(agg_func_4);
-    loader.RegisterFunction(anofox_features_agg_set);
+    {
+        CreateAggregateFunctionInfo info(anofox_features_agg_set);
+        info.alias_of = "ts_features_agg";
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, anofox_fcst_ts_features_agg(date, value) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, anofox_fcst_ts_features_agg(date, value, config) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR))};
+            info.descriptions.push_back(std::move(desc));
+        }
+        {
+            FunctionDescription desc;
+            desc.description = "Aggregate function: extracts 117 tsfresh-compatible time series features for each group. Returns a STRUCT with all computed features.";
+            desc.examples = {"SELECT product_id, anofox_fcst_ts_features_agg(date, value, ['mean'], NULL) FROM sales GROUP BY product_id"};
+            desc.categories = {"time-series", "feature-extraction"};
+            desc.parameter_names = {"date", "value", "feature_selection", "feature_params"};
+            desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR)), LogicalType::LIST(param_struct_type)};
+            info.descriptions.push_back(std::move(desc));
+        }
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_forecast_agg.cpp
+++ b/src/aggregate_functions/ts_forecast_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 #include <cmath>
 
 namespace duckdb {
@@ -596,12 +598,33 @@ void RegisterTsForecastAggFunction(ExtensionLoader &loader) {
 
     AggregateFunctionSet func_set("anofox_fcst_ts_forecast_agg");
     func_set.AddFunction(agg_func);
-    loader.RegisterFunction(func_set);
+    {
+        CreateAggregateFunctionInfo info(func_set);
+        info.alias_of = "ts_forecast_agg";
+        FunctionDescription desc;
+        desc.description = "Aggregate function: produces a time series forecast for each group. Supports 32 forecasting models. Returns STRUCT(point[], lower[], upper[], fitted[], residuals[], model, aic, bic, mse).";
+        desc.examples = {"SELECT product_id, anofox_fcst_ts_forecast_agg(date, value, 'AutoETS', 12, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "forecasting"};
+        desc.parameter_names = {"date", "value", "method", "horizon", "params"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::INTEGER), LogicalType::MAP(LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register as ts_forecast_agg alias
     AggregateFunctionSet alias_set("ts_forecast_agg");
     alias_set.AddFunction(agg_func);
-    loader.RegisterFunction(alias_set);
+    {
+        CreateAggregateFunctionInfo info(alias_set);
+        FunctionDescription desc;
+        desc.description = "Aggregate function: produces a time series forecast for each group. Supports 32 forecasting models. Returns STRUCT(point[], lower[], upper[], fitted[], residuals[], model, aic, bic, mse).";
+        desc.examples = {"SELECT product_id, ts_forecast_agg(date, value, 'AutoETS', 12, MAP{}) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "forecasting"};
+        desc.parameter_names = {"date", "value", "method", "horizon", "params"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::INTEGER), LogicalType::MAP(LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ts_stats_agg.cpp
+++ b/src/aggregate_functions/ts_stats_agg.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 namespace duckdb {
 
@@ -300,12 +302,33 @@ void RegisterTsStatsAggFunction(ExtensionLoader &loader) {
     // Register ts_stats_agg
     AggregateFunctionSet ts_stats_agg_set("ts_stats_agg");
     ts_stats_agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(ts_stats_agg_set);
+    {
+        CreateAggregateFunctionInfo info(ts_stats_agg_set);
+        FunctionDescription desc;
+        desc.description = "Aggregate function: computes 34 time series statistics for each group. Returns a STRUCT with mean, std, min, max, trend, seasonality, and many more.";
+        desc.examples = {"SELECT product_id, ts_stats_agg(date, value) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "statistics"};
+        desc.parameter_names = {"date", "value"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register anofox_fcst_ts_stats_agg alias
     AggregateFunctionSet anofox_stats_agg_set("anofox_fcst_ts_stats_agg");
     anofox_stats_agg_set.AddFunction(agg_func);
-    loader.RegisterFunction(anofox_stats_agg_set);
+    {
+        CreateAggregateFunctionInfo info(anofox_stats_agg_set);
+        info.alias_of = "ts_stats_agg";
+        FunctionDescription desc;
+        desc.description = "Aggregate function: computes 34 time series statistics for each group. Returns a STRUCT with mean, std, min, max, trend, seasonality, and many more.";
+        desc.examples = {"SELECT product_id, anofox_fcst_ts_stats_agg(date, value) FROM sales GROUP BY product_id"};
+        desc.categories = {"time-series", "statistics"};
+        desc.parameter_names = {"date", "value"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::TIMESTAMP), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -2034,11 +2034,6 @@ static unique_ptr<CreateMacroInfo> CreateTableMacro(const TsTableMacro &macro_de
         }
     }
 
-    // Set parameter types to ANY (SQL macros accept any expression type)
-    for (idx_t i = 0; i < function->parameters.size(); i++) {
-        function->types.push_back(LogicalType::ANY);
-    }
-
     // Create the macro info
     auto info = make_uniq<CreateMacroInfo>(CatalogType::TABLE_MACRO_ENTRY);
     info->schema = DEFAULT_SCHEMA;

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -2,6 +2,7 @@
 #include "duckdb.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
+#include "duckdb/parser/parsed_data/create_function_info.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/function/table_macro_function.hpp"
@@ -17,6 +18,9 @@ struct TsTableMacro {
         const char *default_value;
     } named_params[8];                  // Named parameters with defaults
     const char *macro;                  // SQL definition
+    const char *description;            // Added: human-readable description
+    const char *example;                // Added: example SQL usage
+    const char *category;               // Added: primary category
 };
 
 // clang-format off
@@ -76,7 +80,10 @@ SELECT
     (_stats).expected_length AS expected_length,
     (_stats).n_gaps AS n_gaps
 FROM stats_data
-)"},
+)",
+    "Computes 34 time series statistics per group. Returns a wide table with one column per statistic.",
+    "SELECT * FROM ts_stats('sales', product_id, date, qty, '1d')",
+    "statistics"},
 
     // ts_quality_report: Generate quality report from stats table
     // C++ API: ts_quality_report(stats_table, min_length)
@@ -89,7 +96,10 @@ SELECT
     SUM(CASE WHEN is_constant THEN 1 ELSE 0 END) AS n_constant,
     COUNT(*) AS n_total
 FROM query_table(stats_table::VARCHAR)
-)"},
+)",
+    "Generates a data quality report with null counts, gap counts, duplicate timestamps, and quality score per group.",
+    "SELECT * FROM ts_quality_report('sales', product_id, date, qty)",
+    "statistics"},
 
     // ts_stats_summary: Summary statistics from stats table
     // C++ API: ts_stats_summary(stats_table)
@@ -103,7 +113,10 @@ SELECT
     SUM(n_nulls) AS total_nulls,
     SUM(n_nan) AS total_nans
 FROM query_table(stats_table::VARCHAR)
-)"},
+)",
+    "Aggregates ts_stats output across all groups into summary statistics (mean, std, min, max per metric).",
+    "SELECT * FROM ts_stats_summary('sales', product_id, date, qty, '1d')",
+    "statistics"},
 
     // ts_data_quality: Assess data quality per series
     // C++ API: ts_data_quality(table_name, unique_id_col, date_col, value_col, n_short, frequency)
@@ -128,7 +141,10 @@ SELECT
     (_quality).n_missing AS n_missing,
     (_quality).is_constant AS is_constant
 FROM quality_data
-)"},
+)",
+    "Assesses time series data quality per group, returning null rate, gap rate, duplicate count, and quality score.",
+    "SELECT * FROM ts_data_quality('sales', product_id, date, qty)",
+    "data-quality"},
 
     // ts_data_quality_summary: Summarize data quality across series
     // C++ API: ts_data_quality_summary(table_name, unique_id_col, date_col, value_col, n_short)
@@ -148,7 +164,10 @@ SELECT
     SUM(CASE WHEN (_quality).overall_score < 0.5 THEN 1 ELSE 0 END) AS n_poor,
     AVG((_quality).overall_score) AS avg_score
 FROM quality_data
-)"},
+)",
+    "Summarizes ts_data_quality output across all groups into aggregate quality metrics.",
+    "SELECT * FROM ts_data_quality_summary('sales', product_id, date, qty)",
+    "data-quality"},
 
     // ts_drop_constant_by: Filter out constant series (table-based)
     // C++ API: ts_drop_constant_by(table_name, group_col, value_col)
@@ -162,7 +181,10 @@ WHERE group_col IN (
     GROUP BY group_col
     HAVING MIN(value_col) != MAX(value_col) OR MIN(value_col) IS NULL OR MAX(value_col) IS NULL
 )
-)"},
+)",
+    "Removes groups whose time series values are all constant (zero variance).",
+    "SELECT * FROM ts_drop_constant_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_drop_short_by: Filter out short series (table-based)
     // C++ API: ts_drop_short_by(table_name, group_col, min_length)
@@ -176,7 +198,10 @@ WHERE group_col IN (
     GROUP BY group_col
     HAVING COUNT(*) >= min_length
 )
-)"},
+)",
+    "Removes groups with fewer observations than the specified minimum length.",
+    "SELECT * FROM ts_drop_short_by('sales', product_id, date, qty, 20)",
+    "data-preparation"},
 
     // ts_drop_leading_zeros_by: Remove leading zeros from series (table-based)
     // C++ API: ts_drop_leading_zeros_by(table_name, group_col, date_col, value_col)
@@ -190,7 +215,10 @@ WITH first_nonzero AS (
 SELECT * EXCLUDE (_first_nz)
 FROM first_nonzero
 WHERE date_col >= _first_nz
-)"},
+)",
+    "Removes leading zeros from each group's time series, trimming the start of the series.",
+    "SELECT * FROM ts_drop_leading_zeros_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_drop_trailing_zeros_by: Remove trailing zeros from series (table-based)
     // C++ API: ts_drop_trailing_zeros_by(table_name, group_col, date_col, value_col)
@@ -204,7 +232,10 @@ WITH last_nonzero AS (
 SELECT * EXCLUDE (_last_nz)
 FROM last_nonzero
 WHERE date_col <= _last_nz
-)"},
+)",
+    "Removes trailing zeros from each group's time series, trimming the end of the series.",
+    "SELECT * FROM ts_drop_trailing_zeros_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_drop_edge_zeros_by: Remove both leading and trailing zeros (table-based)
     // C++ API: ts_drop_edge_zeros_by(table_name, group_col, date_col, value_col)
@@ -219,7 +250,10 @@ WITH nonzero_bounds AS (
 SELECT * EXCLUDE (_first_nz, _last_nz)
 FROM nonzero_bounds
 WHERE date_col >= _first_nz AND date_col <= _last_nz
-)"},
+)",
+    "Removes both leading and trailing zeros from each group's time series.",
+    "SELECT * FROM ts_drop_edge_zeros_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_fill_nulls_const_by: Fill NULL values with constant (table-based)
     // C++ API: ts_fill_nulls_const_by(table_name, group_col, date_col, value_col, fill_value)
@@ -229,7 +263,10 @@ R"(
 SELECT *, COALESCE(value_col, fill_value) AS filled_value
 FROM query_table(source::VARCHAR)
 ORDER BY group_col, date_col
-)"},
+)",
+    "Fills NULL values in each group's time series with a constant value.",
+    "SELECT * FROM ts_fill_nulls_const_by('sales', product_id, date, qty, 0.0)",
+    "data-preparation"},
 
     // ts_fill_nulls_forward_by: Forward fill (LOCF) (table-based)
     // C++ API: ts_fill_nulls_forward_by(table_name, group_col, date_col, value_col)
@@ -242,7 +279,10 @@ SELECT *,
     )) AS filled_value
 FROM query_table(source::VARCHAR)
 ORDER BY group_col, date_col
-)"},
+)",
+    "Forward-fills NULL values in each group's time series using the last known value.",
+    "SELECT * FROM ts_fill_nulls_forward_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_fill_nulls_backward_by: Backward fill (NOCB) (table-based)
     // C++ API: ts_fill_nulls_backward_by(table_name, group_col, date_col, value_col)
@@ -255,7 +295,10 @@ SELECT *,
     )) AS filled_value
 FROM query_table(source::VARCHAR)
 ORDER BY group_col, date_col
-)"},
+)",
+    "Backward-fills NULL values in each group's time series using the next known value.",
+    "SELECT * FROM ts_fill_nulls_backward_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_fill_nulls_mean_by: Fill with series mean (table-based)
     // C++ API: ts_fill_nulls_mean_by(table_name, group_col, date_col, value_col)
@@ -270,7 +313,10 @@ WITH with_mean AS (
 SELECT * EXCLUDE (_mean_val), COALESCE(value_col, _mean_val) AS filled_value
 FROM with_mean
 ORDER BY group_col, date_col
-)"},
+)",
+    "Fills NULL values in each group's time series with the group mean.",
+    "SELECT * FROM ts_fill_nulls_mean_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_diff_by: Compute differences (table-based)
     // C++ API: ts_diff_by(table_name, group_col, date_col, value_col, diff_order)
@@ -284,7 +330,10 @@ SELECT
     ) AS diff_value
 FROM query_table(source::VARCHAR)
 ORDER BY group_col, date_col
-)"},
+)",
+    "Computes first-order differences for each group's time series (value[t] - value[t-1]).",
+    "SELECT * FROM ts_diff_by('sales', product_id, date, qty)",
+    "data-preparation"},
 
     // ts_fill_gaps_by: Fill date gaps with NULL values at specified frequency
     // C++ API: ts_fill_gaps_by(table_name, group_col, date_col, value_col, frequency)
@@ -302,7 +351,10 @@ SELECT * FROM _ts_fill_gaps_native(
     (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR)),
     frequency
 )
-)"},
+)",
+    "Fills missing timestamps in each group's time series to create a regular frequency grid.",
+    "SELECT * FROM ts_fill_gaps_by('sales', product_id, date, qty, '1d')",
+    "data-preparation"},
 
     // ts_fill_forward_by: Fill forward to a target date with NULL values
     // C++ API: ts_fill_forward_by(table_name, group_col, date_col, value_col, target_date, frequency)
@@ -321,7 +373,10 @@ SELECT * FROM _ts_fill_forward_native(
     target_date,
     frequency
 )
-)"},
+)",
+    "Forward-fills missing timestamps in each group's time series using the last known value.",
+    "SELECT * FROM ts_fill_forward_by('sales', product_id, date, qty, '1d')",
+    "data-preparation"},
 
     // ts_drop_gappy_by: Filter out series with too many gaps
     // C++ API: ts_drop_gappy_by(table_name, group_col, value_col, max_gap_ratio)
@@ -335,7 +390,10 @@ WHERE group_col IN (
     GROUP BY group_col
     HAVING (SUM(CASE WHEN value_col IS NULL THEN 1 ELSE 0 END)::DOUBLE / NULLIF(COUNT(*), 0)) <= max_gap_ratio
 )
-)"},
+)",
+    "Removes groups whose time series have a gap rate exceeding a threshold.",
+    "SELECT * FROM ts_drop_gappy_by('sales', product_id, date, qty, '1d', 0.1)",
+    "data-preparation"},
 
     // ts_drop_zeros_by: Filter out series with all zeros
     // C++ API: ts_drop_zeros_by(table_name, group_col, value_col)
@@ -349,7 +407,10 @@ WHERE group_col IN (
     GROUP BY group_col
     HAVING SUM(CASE WHEN value_col != 0 AND value_col IS NOT NULL THEN 1 ELSE 0 END) > 0
 )
-)"},
+)",
+    "Removes groups whose time series are predominantly zero values.",
+    "SELECT * FROM ts_drop_zeros_by('sales', product_id, date, qty, 0.8)",
+    "data-preparation"},
 
     // ts_mstl_decomposition_by: MSTL decomposition for grouped series
     // C++ API: ts_mstl_decomposition_by(table_name, group_col, date_col, value_col, params MAP)
@@ -361,7 +422,10 @@ SELECT * FROM _ts_mstl_decomposition_native(
     (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR)),
     COALESCE(json_extract_string(to_json(params), '$.insufficient_data'), 'fail')
 )
-)"},
+)",
+    "Decomposes each group's time series into trend, seasonal, and remainder components using MSTL.",
+    "SELECT * FROM ts_mstl_decomposition_by('sales', product_id, date, qty, '[7,365]')",
+    "decomposition"},
 
     // ts_detrend_by: Remove trend from grouped time series
     // C++ API: ts_detrend_by(table_name, group_col, date_col, value_col, method)
@@ -385,7 +449,10 @@ SELECT
     (_detrend).rss AS rss,
     (_detrend).n_params AS n_params
 FROM detrend_data
-)"},
+)",
+    "Removes the trend component from each group's time series.",
+    "SELECT * FROM ts_detrend_by('sales', product_id, date, qty, 7)",
+    "decomposition"},
 
     // ts_classify_seasonality_by: Classify seasonality type per group
     // C++ API: ts_classify_seasonality_by(table_name, group_col, date_col, value_col, period)
@@ -411,7 +478,10 @@ SELECT
     (_cls).cycle_strengths AS cycle_strengths,
     (_cls).weak_seasons AS weak_seasons
 FROM classification_data
-)"},
+)",
+    "Classifies seasonality type (additive/multiplicative/none) for each group.",
+    "SELECT * FROM ts_classify_seasonality_by('sales', product_id, date, qty)",
+    "seasonality"},
 
     // ts_detect_changepoints: Detect changepoints in a single series
     // C++ API: ts_detect_changepoints(table_name, date_col, value_col, params MAP)
@@ -440,7 +510,10 @@ SELECT
     (cp.cp).changepoint_probability[od._idx] AS changepoint_probability
 FROM ordered_data od, cp_result cp
 ORDER BY od._dt
-)"},
+)",
+    "Detects structural changepoints in a single time series using Bayesian Online Changepoint Detection.",
+    "SELECT * FROM ts_detect_changepoints('sales', product_id, date, qty)",
+    "changepoint-detection"},
 
     // ts_detect_changepoints_by: Detect changepoints per group (row-level output)
     // C++ API: ts_detect_changepoints_by(table_name, group_col, date_col, value_col, params MAP)
@@ -456,7 +529,10 @@ SELECT * FROM _ts_detect_changepoints_by_native(
     (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR)),
     COALESCE(TRY_CAST(params['hazard_lambda'] AS VARCHAR), '250.0')
 )
-)"},
+)",
+    "Detects structural changepoints for each group using Bayesian Online Changepoint Detection.",
+    "SELECT * FROM ts_detect_changepoints_by('sales', product_id, date, qty)",
+    "changepoint-detection"},
 
     // ts_forecast: Generate forecasts for a single series (table-based)
     // C++ API: ts_forecast(table_name, date_col, target_col, method, horizon, params?)
@@ -484,7 +560,10 @@ SELECT
     (fcst).aic,
     (fcst).bic
 FROM forecast_result
-)"},
+)",
+    "Generates a forecast for a single time series. Returns point forecasts with prediction intervals.",
+    "SELECT * FROM ts_forecast('sales', product_id, date, qty, 'AutoETS', 12, '1d')",
+    "forecasting"},
 
     // ts_forecast_by: Generate forecasts per group (long format - one row per forecast step)
     // C++ API: ts_forecast_by(table_name, group_col, date_col, target_col, method, horizon, frequency, params?)
@@ -509,7 +588,10 @@ FROM (
     FROM query_table(source::VARCHAR)
     GROUP BY group_col
 )
-)"},
+)",
+    "Generates forecasts for multiple time series grouped by one or more keys. Returns point forecasts with prediction intervals.",
+    "SELECT * FROM ts_forecast_by('sales', product_id, date, qty, 'AutoETS', 12, '1d')",
+    "forecasting"},
 
     // ts_cv_forecast_by: Generate forecasts for CV splits with parallel fold execution
     // C++ API: ts_cv_forecast_by(ml_folds, group_col, date_col, target_col, method, params)
@@ -536,7 +618,10 @@ SELECT * FROM _ts_cv_forecast_native(
     params
 )
 ORDER BY 1, 2, 3
-)"},
+)",
+    "Runs forecasts on all cross-validation folds and returns predictions with fold metadata.",
+    "SELECT * FROM ts_cv_forecast_by('cv_splits', product_id, date, qty, 'AutoETS')",
+    "cross-validation"},
 
     // ts_forecast_exog: Generate forecasts with exogenous variables (single series)
     // C++ API: ts_forecast_exog(source, date_col, target_col, xreg_cols, future_source, future_date_col, future_xreg_cols, method, horizon, params)
@@ -611,7 +696,10 @@ SELECT
     (fcst).bic,
     (fcst).mse
 FROM forecast_result
-)"},
+)",
+    "Generates a forecast for a single time series using exogenous regressors.",
+    "SELECT * FROM ts_forecast_exog('sales', product_id, date, qty, 'future_features', 'AutoARIMA', 12, '1d')",
+    "forecasting"},
 
     // ts_forecast_exog_by: Generate forecasts with exogenous variables per group
     // C++ API: ts_forecast_exog_by(source, group_col, date_col, target_col, xreg_cols, future_source, future_date_col, future_xreg_cols, frequency, method?, horizon?, params?)
@@ -721,7 +809,10 @@ SELECT
     (fcst).model AS model_name
 FROM forecast_data
 ORDER BY __exog_grp__, forecast_step
-)"},
+)",
+    "Generates forecasts for multiple time series using exogenous regressors.",
+    "SELECT * FROM ts_forecast_exog_by('sales', product_id, date, qty, 'future_features', 'AutoARIMA', 12, '1d')",
+    "forecasting"},
 
     // ts_mark_unknown_by: Mark rows as known/unknown based on cutoff date for scenario expressions
     // C++ API: ts_mark_unknown_by(table_name, group_col, date_col, cutoff_date)
@@ -754,7 +845,10 @@ SELECT
 FROM src
 LEFT JOIN last_known lk ON src._grp = lk._grp
 ORDER BY src._grp, src._dt
-)"},
+)",
+    "Marks future values as unknown (NULL) for cross-validation leakage prevention.",
+    "SELECT * FROM ts_mark_unknown_by('features', product_id, date, feature_col, cutoff_date)",
+    "data-preparation"},
 
     // ts_fill_unknown_by: Fill unknown future feature values in test set for CV splits
     // C++ API: ts_fill_unknown_by(table_name, group_col, date_col, value_col, cutoff_date, params)
@@ -792,7 +886,10 @@ SELECT
     END AS value_col
 FROM src
 ORDER BY _grp, _dt
-)"},
+)",
+    "Fills unknown (NULL) feature values using a specified strategy for cross-validation.",
+    "SELECT * FROM ts_fill_unknown_by('cv_data', product_id, date, feature_col, 'last_value')",
+    "data-preparation"},
 
     // ts_validate_timestamps_by: Validate that expected timestamps exist in data for each group
     // C++ API: ts_validate_timestamps_by(table_name, group_col, date_col, expected_timestamps)
@@ -835,7 +932,10 @@ SELECT
 FROM validation
 GROUP BY _grp
 ORDER BY _grp
-)"},
+)",
+    "Validates that timestamps are unique, monotonically increasing, and match the expected frequency per group.",
+    "SELECT * FROM ts_validate_timestamps_by('sales', product_id, date, qty, '1d')",
+    "data-quality"},
 
     // ts_validate_timestamps_summary_by: Quick validation summary across all groups
     // C++ API: ts_validate_timestamps_summary_by(table_name, group_col, date_col, expected_timestamps)
@@ -881,7 +981,10 @@ SELECT
     SUM(CASE WHEN NOT is_valid THEN 1 ELSE 0 END)::BIGINT AS n_invalid_groups,
     LIST(_grp) FILTER (WHERE NOT is_valid) AS invalid_groups
 FROM per_group
-)"},
+)",
+    "Summarizes ts_validate_timestamps_by results across all groups.",
+    "SELECT * FROM ts_validate_timestamps_summary_by('sales', product_id, date, qty, '1d')",
+    "data-quality"},
 
     // ts_cv_split_folds_by: Generate fold boundaries for time series cross-validation
     // C++ API: ts_cv_split_folds_by(source, group_col, date_col, training_end_times, horizon, frequency, params)
@@ -959,7 +1062,10 @@ SELECT
     (SELECT _embargo FROM _params)::BIGINT AS embargo
 FROM folds_with_embargo
 ORDER BY fold_id
-)"},
+)",
+    "Splits time series into cross-validation folds with configurable gap, embargo, and window parameters.",
+    "SELECT * FROM ts_cv_split_folds_by('sales', product_id, date, qty, 3, 12, '1d')",
+    "cross-validation"},
 
     // ts_cv_split_by: Split time series data into train/test sets for cross-validation
     // C++ API: ts_cv_split_by(source, group_col, date_col, target_col, training_end_times, horizon, params)
@@ -980,7 +1086,10 @@ SELECT * FROM _ts_cv_split_native(
     params
 )
 ORDER BY 4, 1, 2
-)"},
+)",
+    "Creates cross-validation train/test splits from explicit fold boundary dates.",
+    "SELECT * FROM ts_cv_split_by('sales', product_id, date, qty, 'folds', fold_id, cutoff)",
+    "cross-validation"},
 
     // ts_cv_split_index_by: Memory-efficient CV split that returns only index columns (no data columns)
     // C++ API: ts_cv_split_index_by(source, group_col, date_col, training_end_times, horizon, frequency, params)
@@ -1075,7 +1184,10 @@ CROSS JOIN fold_bounds fb
 WHERE (s._dt >= fb.train_start AND s._dt <= fb.train_end)
    OR (s._dt >= fb.test_start AND s._dt <= fb.test_end)
 ORDER BY fb.fold_id, s._grp, s._dt
-)"},
+)",
+    "Memory-efficient cross-validation split using row indices instead of full data copies.",
+    "SELECT * FROM ts_cv_split_index_by('sales', product_id, date, qty, 3, 12, '1d')",
+    "cross-validation"},
 
     // ts_check_leakage: Validate a query result doesn't have obvious data leakage
     // C++ API: ts_check_leakage(result_table, test_filter_col, check_cols, params)
@@ -1102,7 +1214,10 @@ SELECT
     'Use ts_hydrate_split_strict + explicit column selection for fail-safe joins' AS recommendation
 FROM stats
 LIMIT 1
-)"},
+)",
+    "Audits a cross-validation dataset for data leakage by checking that test features are not visible during training.",
+    "SELECT * FROM ts_check_leakage('cv_splits', product_id, date, fold_id, split)",
+    "cross-validation"},
 
     // ts_cv_folds_by: Create train/test splits for ML model backtesting
     // C++ API: ts_cv_folds_by(source, group_col, date_col, target_col, n_folds, horizon, params)
@@ -1138,7 +1253,10 @@ SELECT * FROM _ts_cv_folds_native(
     horizon,
     params
 )
-)"},
+)",
+    "Generates cross-validation fold definitions (cutoff dates) without splitting the data.",
+    "SELECT * FROM ts_cv_folds_by('sales', product_id, date, qty, 3, 12, '1d')",
+    "cross-validation"},
 
     // ts_cv_hydrate_by: Hydrate CV folds with unknown features as direct columns
     // C++ API: ts_cv_hydrate_by(cv_folds, source, group_col, date_col, unknown_features, params)
@@ -1197,7 +1315,10 @@ SELECT * FROM _ts_cv_hydrate_native(
     unknown_features,
     params
 )
-)"},
+)",
+    "Joins external features to CV splits with proper masking to prevent data leakage.",
+    "SELECT * FROM ts_cv_hydrate_by('cv_splits', product_id, date, qty, 'features', unknown_cols)",
+    "cross-validation"},
 
     // ts_conformal_by: Compute conformal prediction intervals for grouped series
     // C++ API: ts_conformal_by(backtest_results, group_col, actual_col, forecast_col, point_forecast_col, params)
@@ -1258,7 +1379,10 @@ SELECT
     (conf_result).conformity_score AS conformity_score,
     (conf_result).method AS method
 FROM conformal_calc
-)"},
+)",
+    "One-step conformal prediction: calibrates on backtest residuals and applies to new forecasts.",
+    "SELECT * FROM ts_conformal_by('backtest', product_id, actual, forecast, point_forecast)",
+    "conformal-prediction"},
 
     // ts_conformal_calibrate: Compute conformal quantile from backtest residuals
     // C++ API: ts_conformal_calibrate(backtest_results, actual_col, forecast_col, params)
@@ -1283,7 +1407,10 @@ SELECT
     1.0 - (SELECT _alpha FROM _params) AS coverage,
     COUNT(*)::BIGINT AS n_residuals
 FROM residuals
-)"},
+)",
+    "Calibrates a conformal predictor from backtest residuals and returns the calibration profile for reuse.",
+    "SELECT * FROM ts_conformal_calibrate('backtest', product_id, actual, forecast)",
+    "conformal-prediction"},
 
     // ts_conformal_apply_by: Apply pre-computed conformity score to forecasts
     // C++ API: ts_conformal_apply_by(forecast_results, group_col, forecast_col, conformity_score)
@@ -1308,7 +1435,10 @@ SELECT
     (interval_result).lower AS lower,
     (interval_result).upper AS upper
 FROM intervals
-)"},
+)",
+    "Applies a pre-calibrated conformal profile to new point forecasts to generate prediction intervals.",
+    "SELECT * FROM ts_conformal_apply_by('forecasts', product_id, date, point_forecast, calibration_profile)",
+    "conformal-prediction"},
 
     // ts_interval_width_by: Compute mean interval width for grouped series
     // C++ API: ts_interval_width_by(results, group_col, lower_col, upper_col)
@@ -1325,7 +1455,10 @@ SELECT
 FROM query_table(results::VARCHAR)
 WHERE lower_col IS NOT NULL AND upper_col IS NOT NULL
 GROUP BY group_col
-)"},
+)",
+    "Computes the mean width of prediction intervals for each group.",
+    "SELECT * FROM ts_interval_width_by('forecasts', product_id, lower, upper)",
+    "conformal-prediction"},
 
     // ================================================================================
     // Multi-key unique_id functions (Issue #78)
@@ -1349,7 +1482,10 @@ SELECT * FROM _ts_stats_by_native(
     (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR)),
     frequency
 )
-)"},
+)",
+    "Alias for ts_stats. Computes 34 time series statistics per group.",
+    "SELECT * FROM ts_stats_by('sales', product_id, date, qty, '1d')",
+    "statistics"},
 
     // ts_data_quality_by: Alias for ts_data_quality (for API consistency with _by naming pattern)
     // C++ API: ts_data_quality_by(table_name, unique_id_col, date_col, value_col, n_short, frequency)
@@ -1374,7 +1510,10 @@ SELECT
     (_quality).n_missing AS n_missing,
     (_quality).is_constant AS is_constant
 FROM quality_data
-)"},
+)",
+    "Alias for ts_data_quality. Assesses time series data quality per group.",
+    "SELECT * FROM ts_data_quality_by('sales', product_id, date, qty)",
+    "data-quality"},
 
     // ts_features_table: Extract features from a single-series table
     // C++ API: ts_features_table(table_name, date_col, value_col)
@@ -1503,7 +1642,10 @@ SELECT
     (_feat).variation_coefficient AS variation_coefficient,
     (_feat).zero_crossing_rate AS zero_crossing_rate
 FROM features_data
-)"},
+)",
+    "Extracts 117 tsfresh-compatible features and returns them as a wide table (one column per feature).",
+    "SELECT * FROM ts_features_table('sales', product_id, date, qty)",
+    "feature-extraction"},
 
     // ts_features_by: Extract features per group (native streaming implementation)
     // C++ API: ts_features_by(table_name, group_col, date_col, value_col)
@@ -1513,7 +1655,10 @@ R"(
 SELECT * FROM _ts_features_native(
     (SELECT group_col, date_col, value_col FROM query_table(source::VARCHAR))
 )
-)"},
+)",
+    "Extracts time series features for each group and returns results as a structured table.",
+    "SELECT * FROM ts_features_by('sales', product_id, date, qty)",
+    "feature-extraction"},
 
     // ts_classify_seasonality: Classify seasonality for a single series
     // C++ API: ts_classify_seasonality(table_name, date_col, value_col, period)
@@ -1536,7 +1681,10 @@ SELECT
     (_cls).cycle_strengths AS cycle_strengths,
     (_cls).weak_seasons AS weak_seasons
 FROM classification_data
-)"},
+)",
+    "Single-series seasonality classification. Classifies seasonality type and returns timing metadata.",
+    "SELECT * FROM ts_classify_seasonality('sales', product_id, date, qty)",
+    "seasonality"},
 
     // ================================================================================
     // Period Detection
@@ -1570,7 +1718,10 @@ SELECT
     (_periods).primary_period AS primary_period,
     (_periods).method AS method
 FROM periods_data
-)"},
+)",
+    "Detects seasonal periods for a single time series, returning ranked period candidates with confidence scores.",
+    "SELECT * FROM ts_detect_periods('sales', product_id, date, qty)",
+    "period-detection"},
 
     // ts_detect_periods_by: Detect periods for grouped series
     // C++ API: ts_detect_periods_by(table_name, group_col, date_col, value_col, params)
@@ -1604,7 +1755,10 @@ SELECT
     (_periods).primary_period AS primary_period,
     (_periods).method AS method
 FROM periods_data
-)"},
+)",
+    "Detects seasonal periods for each group, returning ranked period candidates with confidence scores.",
+    "SELECT * FROM ts_detect_periods_by('sales', product_id, date, qty)",
+    "period-detection"},
 
     // ts_detect_peaks_by: Detect peaks for grouped series
     // C++ API: ts_detect_peaks_by(table_name, group_col, date_col, value_col, params)
@@ -1631,7 +1785,10 @@ SELECT
     (_peaks).inter_peak_distances AS inter_peak_distances,
     (_peaks).mean_period AS mean_period
 FROM peaks_data
-)"},
+)",
+    "Detects peaks in each group's time series, returning peak indices, values, and prominence scores.",
+    "SELECT * FROM ts_detect_peaks_by('sales', product_id, date, qty)",
+    "peak-detection"},
 
     // ts_detect_peaks: Detect peaks for a single series
     // C++ API: ts_detect_peaks(table_name, date_col, value_col, params)
@@ -1655,7 +1812,10 @@ SELECT
     (_peaks).inter_peak_distances AS inter_peak_distances,
     (_peaks).mean_period AS mean_period
 FROM peaks_data
-)"},
+)",
+    "Detects peaks in a single time series, returning peak indices, values, and prominence scores.",
+    "SELECT * FROM ts_detect_peaks('sales', product_id, date, qty)",
+    "peak-detection"},
 
     // ts_analyze_peak_timing_by: Analyze peak timing for grouped series
     // C++ API: ts_analyze_peak_timing_by(table_name, group_col, date_col, value_col, period, params)
@@ -1679,7 +1839,10 @@ SELECT
     (_timing).variability_score AS variability_score,
     (_timing).is_stable AS is_stable
 FROM timing_data
-)"},
+)",
+    "Analyzes peak timing variability for each group, returning timing statistics and stability score.",
+    "SELECT * FROM ts_analyze_peak_timing_by('sales', product_id, date, qty, 7)",
+    "peak-detection"},
 
     // ts_analyze_peak_timing: Analyze peak timing for a single series
     // C++ API: ts_analyze_peak_timing(table_name, date_col, value_col, period, params)
@@ -1700,7 +1863,10 @@ SELECT
     (_timing).variability_score AS variability_score,
     (_timing).is_stable AS is_stable
 FROM timing_data
-)"},
+)",
+    "Analyzes peak timing variability for a single time series.",
+    "SELECT * FROM ts_analyze_peak_timing('sales', product_id, date, qty, 7)",
+    "peak-detection"},
 
     // ================================================================================
     // Metrics Table Macros (DEPRECATED)
@@ -1728,80 +1894,113 @@ FROM timing_data
     {"ts_mae_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'mae')
-)"},
+)",
+    "Computes Mean Absolute Error between actual and forecast columns per group.",
+    "SELECT * FROM ts_mae_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_mse_by: Compute Mean Squared Error grouped by selected columns
     // C++ API: ts_mse_by(source, date_col, actual_col, forecast_col)
     {"ts_mse_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'mse')
-)"},
+)",
+    "Computes Mean Squared Error between actual and forecast columns per group.",
+    "SELECT * FROM ts_mse_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_rmse_by: Compute Root Mean Squared Error grouped by selected columns
     // C++ API: ts_rmse_by(source, date_col, actual_col, forecast_col)
     {"ts_rmse_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'rmse')
-)"},
+)",
+    "Computes Root Mean Squared Error between actual and forecast columns per group.",
+    "SELECT * FROM ts_rmse_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_mape_by: Compute Mean Absolute Percentage Error grouped by selected columns
     // C++ API: ts_mape_by(source, date_col, actual_col, forecast_col)
     {"ts_mape_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'mape')
-)"},
+)",
+    "Computes Mean Absolute Percentage Error between actual and forecast columns per group.",
+    "SELECT * FROM ts_mape_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_smape_by: Compute Symmetric Mean Absolute Percentage Error grouped by selected columns
     // C++ API: ts_smape_by(source, date_col, actual_col, forecast_col)
     {"ts_smape_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'smape')
-)"},
+)",
+    "Computes Symmetric Mean Absolute Percentage Error between actual and forecast columns per group.",
+    "SELECT * FROM ts_smape_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_r2_by: Compute R-squared (coefficient of determination) grouped by selected columns
     // C++ API: ts_r2_by(source, date_col, actual_col, forecast_col)
     {"ts_r2_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'r2')
-)"},
+)",
+    "Computes R-squared (coefficient of determination) between actual and forecast columns per group.",
+    "SELECT * FROM ts_r2_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_bias_by: Compute bias (mean error) grouped by selected columns
     // C++ API: ts_bias_by(source, date_col, actual_col, forecast_col)
     {"ts_bias_by", {"source", "date_col", "actual_col", "forecast_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_metrics_native(source, date_col, actual_col, forecast_col, 'bias')
-)"},
+)",
+    "Computes mean forecast bias between actual and forecast columns per group.",
+    "SELECT * FROM ts_bias_by('results', product_id, date, actual, forecast)",
+    "metrics"},
 
     // ts_mase_by: Compute Mean Absolute Scaled Error with GROUP BY ALL
     // C++ API: ts_mase_by(source, date_col, actual_col, forecast_col, baseline_col)
     {"ts_mase_by", {"source", "date_col", "actual_col", "forecast_col", "baseline_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_mase_native(source, date_col, actual_col, forecast_col, baseline_col)
-)"},
+)",
+    "Computes Mean Absolute Scaled Error comparing forecast to a baseline model per group.",
+    "SELECT * FROM ts_mase_by('results', product_id, date, actual, forecast, baseline)",
+    "metrics"},
 
     // ts_rmae_by: Compute Relative Mean Absolute Error with GROUP BY ALL
     // C++ API: ts_rmae_by(source, date_col, actual_col, pred1_col, pred2_col)
     {"ts_rmae_by", {"source", "date_col", "actual_col", "pred1_col", "pred2_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_rmae_native(source, date_col, actual_col, pred1_col, pred2_col)
-)"},
+)",
+    "Computes Relative MAE (MAE ratio between two models) per group.",
+    "SELECT * FROM ts_rmae_by('results', product_id, date, actual, pred1, pred2)",
+    "metrics"},
 
     // ts_coverage_by: Compute prediction interval coverage with GROUP BY ALL
     // C++ API: ts_coverage_by(source, date_col, actual_col, lower_col, upper_col)
     {"ts_coverage_by", {"source", "date_col", "actual_col", "lower_col", "upper_col", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_coverage_native(source, date_col, actual_col, lower_col, upper_col)
-)"},
+)",
+    "Computes prediction interval coverage rate per group.",
+    "SELECT * FROM ts_coverage_by('results', product_id, date, actual, lower, upper)",
+    "metrics"},
 
     // ts_quantile_loss_by: Compute quantile loss with GROUP BY ALL
     // C++ API: ts_quantile_loss_by(source, date_col, actual_col, forecast_col, quantile)
     {"ts_quantile_loss_by", {"source", "date_col", "actual_col", "forecast_col", "quantile", nullptr}, {{nullptr, nullptr}},
 R"(
 SELECT * FROM _ts_quantile_loss_native(source, date_col, actual_col, forecast_col, quantile)
-)"},
+)",
+    "Computes quantile (pinball) loss at a specified quantile level per group.",
+    "SELECT * FROM ts_quantile_loss_by('results', product_id, date, actual, forecast, 0.9)",
+    "metrics"},
 
     // Sentinel
-    {nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
+    {nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr, nullptr, nullptr, nullptr}
 };
 // clang-format on
 
@@ -1835,6 +2034,11 @@ static unique_ptr<CreateMacroInfo> CreateTableMacro(const TsTableMacro &macro_de
         }
     }
 
+    // Set parameter types to ANY (SQL macros accept any expression type)
+    for (idx_t i = 0; i < function->parameters.size(); i++) {
+        function->types.push_back(LogicalType::ANY);
+    }
+
     // Create the macro info
     auto info = make_uniq<CreateMacroInfo>(CatalogType::TABLE_MACRO_ENTRY);
     info->schema = DEFAULT_SCHEMA;
@@ -1842,6 +2046,20 @@ static unique_ptr<CreateMacroInfo> CreateTableMacro(const TsTableMacro &macro_de
     info->temporary = true;
     info->internal = true;
     info->macros.push_back(std::move(function));
+
+    // Populate description if provided
+    if (macro_def.description) {
+        FunctionDescription desc;
+        desc.description = macro_def.description;
+        if (macro_def.example) {
+            desc.examples.push_back(macro_def.example);
+        }
+        if (macro_def.category) {
+            desc.categories.push_back("time-series");
+            desc.categories.push_back(macro_def.category);
+        }
+        info->descriptions.push_back(std::move(desc));
+    }
 
     return info;
 }
@@ -1855,6 +2073,7 @@ void RegisterTsTableMacros(ExtensionLoader &loader) {
         // Register the prefixed alias (e.g. anofox_fcst_ts_forecast_by)
         auto alias_info = CreateTableMacro(ts_table_macros[i]);
         alias_info->name = "anofox_fcst_" + string(ts_table_macros[i].name);
+        alias_info->alias_of = string(ts_table_macros[i].name);
         loader.RegisterFunction(*alias_info);
     }
 }

--- a/src/scalar_functions/bootstrap.cpp
+++ b/src/scalar_functions/bootstrap.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -131,7 +133,23 @@ void RegisterTsBootstrapIntervalsFunction(ExtensionLoader &loader) {
         result_type,
         TsBootstrapIntervalsFunction
     ));
-    loader.RegisterFunction(bs_set);
+    {
+        CreateScalarFunctionInfo info(bs_set);
+        FunctionDescription desc;
+        desc.description = "Generates bootstrap prediction intervals by resampling historical residuals. Returns STRUCT(point[], lower[], upper[], coverage).";
+        desc.examples = {"ts_bootstrap_intervals(residuals, point_forecast, 1000, 0.90, 42)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"residuals", "forecasts", "n_paths", "coverage", "seed"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::INTEGER),
+            LogicalType(LogicalTypeId::DOUBLE),
+            LogicalType(LogicalTypeId::BIGINT)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_bootstrap_intervals");
     anofox_set.AddFunction(ScalarFunction(
@@ -143,7 +161,24 @@ void RegisterTsBootstrapIntervalsFunction(ExtensionLoader &loader) {
         result_type,
         TsBootstrapIntervalsFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_bootstrap_intervals";
+        FunctionDescription desc;
+        desc.description = "Generates bootstrap prediction intervals by resampling historical residuals. Returns STRUCT(point[], lower[], upper[], coverage).";
+        desc.examples = {"ts_bootstrap_intervals(residuals, point_forecast, 1000, 0.90, 42)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"residuals", "forecasts", "n_paths", "coverage", "seed"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::INTEGER),
+            LogicalType(LogicalTypeId::DOUBLE),
+            LogicalType(LogicalTypeId::BIGINT)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -236,7 +271,23 @@ void RegisterTsBootstrapQuantilesFunction(ExtensionLoader &loader) {
         result_type,
         TsBootstrapQuantilesFunction
     ));
-    loader.RegisterFunction(bq_set);
+    {
+        CreateScalarFunctionInfo info(bq_set);
+        FunctionDescription desc;
+        desc.description = "Generates bootstrap quantile intervals by resampling historical residuals. Returns STRUCT(point[], quantiles[], values[][]).";
+        desc.examples = {"ts_bootstrap_quantiles(residuals, point_forecast, 1000, [0.1, 0.5, 0.9], 42)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"residuals", "forecasts", "n_paths", "quantiles", "seed"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::INTEGER),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::BIGINT)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_bootstrap_quantiles");
     anofox_set.AddFunction(ScalarFunction(
@@ -248,7 +299,24 @@ void RegisterTsBootstrapQuantilesFunction(ExtensionLoader &loader) {
         result_type,
         TsBootstrapQuantilesFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_bootstrap_quantiles";
+        FunctionDescription desc;
+        desc.description = "Generates bootstrap quantile intervals by resampling historical residuals. Returns STRUCT(point[], quantiles[], values[][]).";
+        desc.examples = {"ts_bootstrap_quantiles(residuals, point_forecast, 1000, [0.1, 0.5, 0.9], 42)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"residuals", "forecasts", "n_paths", "quantiles", "seed"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::INTEGER),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::BIGINT)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/conformal.cpp
+++ b/src/scalar_functions/conformal.cpp
@@ -4,7 +4,9 @@
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -78,7 +80,20 @@ void RegisterTsConformalQuantileFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsConformalQuantileFunction
     ));
-    loader.RegisterFunction(ts_cq_set);
+    {
+        CreateScalarFunctionInfo info(ts_cq_set);
+        FunctionDescription desc;
+        desc.description = "Computes the conformal quantile from calibration nonconformity scores at a given miscoverage rate alpha.";
+        desc.examples = {"ts_conformal_quantile(calibration_scores, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"calibration_scores", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_quantile");
     anofox_set.AddFunction(ScalarFunction(
@@ -86,7 +101,21 @@ void RegisterTsConformalQuantileFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsConformalQuantileFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_quantile";
+        FunctionDescription desc;
+        desc.description = "Computes the conformal quantile from calibration nonconformity scores at a given miscoverage rate alpha.";
+        desc.examples = {"ts_conformal_quantile(calibration_scores, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"calibration_scores", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -175,7 +204,20 @@ void RegisterTsConformalIntervalsFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalIntervalsFunction
     ));
-    loader.RegisterFunction(ts_ci_set);
+    {
+        CreateScalarFunctionInfo info(ts_ci_set);
+        FunctionDescription desc;
+        desc.description = "Computes symmetric conformal prediction intervals by applying a conformal quantile to point forecasts.";
+        desc.examples = {"ts_conformal_intervals(point_forecast, conformal_q)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"point_forecast", "conformal_q"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_intervals");
     anofox_set.AddFunction(ScalarFunction(
@@ -183,7 +225,21 @@ void RegisterTsConformalIntervalsFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalIntervalsFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_intervals";
+        FunctionDescription desc;
+        desc.description = "Computes symmetric conformal prediction intervals by applying a conformal quantile to point forecasts.";
+        desc.examples = {"ts_conformal_intervals(point_forecast, conformal_q)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"point_forecast", "conformal_q"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -301,7 +357,21 @@ void RegisterTsConformalPredictFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictFunction
     ));
-    loader.RegisterFunction(ts_cp_set);
+    {
+        CreateScalarFunctionInfo info(ts_cp_set);
+        FunctionDescription desc;
+        desc.description = "End-to-end symmetric conformal prediction: calibrates on residuals and applies to forecasts in one step.";
+        desc.examples = {"ts_conformal_predict(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "forecasts", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_predict");
     anofox_set.AddFunction(ScalarFunction(
@@ -309,7 +379,22 @@ void RegisterTsConformalPredictFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_predict";
+        FunctionDescription desc;
+        desc.description = "End-to-end symmetric conformal prediction: calibrates on residuals and applies to forecasts in one step.";
+        desc.examples = {"ts_conformal_predict(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "forecasts", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -427,7 +512,21 @@ void RegisterTsConformalPredictAsymmetricFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictAsymmetricFunction
     ));
-    loader.RegisterFunction(ts_cpa_set);
+    {
+        CreateScalarFunctionInfo info(ts_cpa_set);
+        FunctionDescription desc;
+        desc.description = "End-to-end asymmetric conformal prediction using separate upper and lower quantiles for skewed errors.";
+        desc.examples = {"ts_conformal_predict_asymmetric(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "forecasts", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_predict_asymmetric");
     anofox_set.AddFunction(ScalarFunction(
@@ -435,7 +534,22 @@ void RegisterTsConformalPredictAsymmetricFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictAsymmetricFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_predict_asymmetric";
+        FunctionDescription desc;
+        desc.description = "End-to-end asymmetric conformal prediction using separate upper and lower quantiles for skewed errors.";
+        desc.examples = {"ts_conformal_predict_asymmetric(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "forecasts", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -624,7 +738,22 @@ void RegisterTsConformalLearnFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalLearnFunction
     ));
-    loader.RegisterFunction(ts_cl_set);
+    {
+        CreateScalarFunctionInfo info(ts_cl_set);
+        FunctionDescription desc;
+        desc.description = "Calibrates a conformal predictor from calibration set actuals and forecasts. Returns conformal quantile for reuse.";
+        desc.examples = {"ts_conformal_learn(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "alphas", "method", "strategy"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::VARCHAR),
+            LogicalType(LogicalTypeId::VARCHAR)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_learn");
     anofox_set.AddFunction(ScalarFunction(
@@ -632,7 +761,23 @@ void RegisterTsConformalLearnFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalLearnFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_learn";
+        FunctionDescription desc;
+        desc.description = "Calibrates a conformal predictor from calibration set actuals and forecasts. Returns conformal quantile for reuse.";
+        desc.examples = {"ts_conformal_learn(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"residuals", "alphas", "method", "strategy"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::VARCHAR),
+            LogicalType(LogicalTypeId::VARCHAR)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -798,7 +943,20 @@ void RegisterTsConformalApplyFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalApplyFunction
     ));
-    loader.RegisterFunction(ts_ca_set);
+    {
+        CreateScalarFunctionInfo info(ts_ca_set);
+        FunctionDescription desc;
+        desc.description = "Applies a pre-calibrated conformal quantile to new point forecasts to produce prediction intervals.";
+        desc.examples = {"ts_conformal_apply(point_forecast, conformal_q)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"point_forecast", "profile"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            profile_type
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_apply");
     anofox_set.AddFunction(ScalarFunction(
@@ -806,7 +964,21 @@ void RegisterTsConformalApplyFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalApplyFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_apply";
+        FunctionDescription desc;
+        desc.description = "Applies a pre-calibrated conformal quantile to new point forecasts to produce prediction intervals.";
+        desc.examples = {"ts_conformal_apply(point_forecast, conformal_q)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"point_forecast", "profile"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            profile_type
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -864,7 +1036,21 @@ void RegisterTsConformalCoverageFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsConformalCoverageFunction
     ));
-    loader.RegisterFunction(ts_cc_set);
+    {
+        CreateScalarFunctionInfo info(ts_cc_set);
+        FunctionDescription desc;
+        desc.description = "Computes empirical coverage rate of conformal prediction intervals on a test set.";
+        desc.examples = {"ts_conformal_coverage(actual, lower, upper)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"actual", "lower", "upper"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_coverage");
     anofox_set.AddFunction(ScalarFunction(
@@ -872,7 +1058,22 @@ void RegisterTsConformalCoverageFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsConformalCoverageFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_coverage";
+        FunctionDescription desc;
+        desc.description = "Computes empirical coverage rate of conformal prediction intervals on a test set.";
+        desc.examples = {"ts_conformal_coverage(actual, lower, upper)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"actual", "lower", "upper"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -955,7 +1156,22 @@ void RegisterTsConformalEvaluateFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalEvaluateFunction
     ));
-    loader.RegisterFunction(ts_ce_set);
+    {
+        CreateScalarFunctionInfo info(ts_ce_set);
+        FunctionDescription desc;
+        desc.description = "Evaluates conformal interval quality returning coverage, mean width, and efficiency metrics.";
+        desc.examples = {"ts_conformal_evaluate(actual, lower, upper, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"actual", "lower", "upper", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_evaluate");
     anofox_set.AddFunction(ScalarFunction(
@@ -963,7 +1179,23 @@ void RegisterTsConformalEvaluateFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalEvaluateFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_evaluate";
+        FunctionDescription desc;
+        desc.description = "Evaluates conformal interval quality returning coverage, mean width, and efficiency metrics.";
+        desc.examples = {"ts_conformal_evaluate(actual, lower, upper, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"actual", "lower", "upper", "alpha"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -1017,7 +1249,20 @@ void RegisterTsMeanIntervalWidthFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMeanIntervalWidthFunction
     ));
-    loader.RegisterFunction(ts_miw_set);
+    {
+        CreateScalarFunctionInfo info(ts_miw_set);
+        FunctionDescription desc;
+        desc.description = "Computes the mean width of prediction intervals: average of (upper - lower) across all steps.";
+        desc.examples = {"ts_mean_interval_width(lower, upper)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"lower", "upper"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mean_interval_width");
     anofox_set.AddFunction(ScalarFunction(
@@ -1025,7 +1270,21 @@ void RegisterTsMeanIntervalWidthFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMeanIntervalWidthFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mean_interval_width";
+        FunctionDescription desc;
+        desc.description = "Computes the mean width of prediction intervals: average of (upper - lower) across all steps.";
+        desc.examples = {"ts_mean_interval_width(lower, upper)"};
+        desc.categories = {"time-series", "uncertainty"};
+        desc.parameter_names = {"lower", "upper"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -1149,7 +1408,23 @@ void RegisterTsConformalPredictPerStepFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictPerStepFunction
     ));
-    loader.RegisterFunction(ps_set);
+    {
+        CreateScalarFunctionInfo info(ps_set);
+        FunctionDescription desc;
+        desc.description = "Per-step conformal prediction that calibrates separate intervals for each forecast horizon step.";
+        desc.examples = {"ts_conformal_predict_per_step(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"fold_forecasts", "fold_actuals", "point_forecasts", "alpha", "horizon"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE),
+            LogicalType(LogicalTypeId::INTEGER)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_conformal_predict_per_step");
     anofox_set.AddFunction(ScalarFunction(
@@ -1161,7 +1436,24 @@ void RegisterTsConformalPredictPerStepFunction(ExtensionLoader &loader) {
         result_type,
         TsConformalPredictPerStepFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_conformal_predict_per_step";
+        FunctionDescription desc;
+        desc.description = "Per-step conformal prediction that calibrates separate intervals for each forecast horizon step.";
+        desc.examples = {"ts_conformal_predict_per_step(calibration_actuals, calibration_forecasts, point_forecast, 0.1)"};
+        desc.categories = {"time-series", "uncertainty", "conformal-prediction"};
+        desc.parameter_names = {"fold_forecasts", "fold_actuals", "point_forecasts", "alpha", "horizon"};
+        desc.parameter_types = {
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
+            LogicalType(LogicalTypeId::DOUBLE),
+            LogicalType(LogicalTypeId::INTEGER)
+        };
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/metrics.cpp
+++ b/src/scalar_functions/metrics.cpp
@@ -5,6 +5,7 @@
 
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 namespace duckdb {
 
@@ -74,7 +75,17 @@ void RegisterTsMaeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMaeFunction
     ));
-    loader.RegisterFunction(ts_mae_set);
+    {
+        CreateScalarFunctionInfo info(ts_mae_set);
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Error (MAE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mae(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mae");
     anofox_set.AddFunction(ScalarFunction(
@@ -82,7 +93,18 @@ void RegisterTsMaeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMaeFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mae";
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Error (MAE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mae(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -131,7 +153,17 @@ void RegisterTsMseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMseFunction
     ));
-    loader.RegisterFunction(ts_mse_set);
+    {
+        CreateScalarFunctionInfo info(ts_mse_set);
+        FunctionDescription desc;
+        desc.description = "Computes Mean Squared Error (MSE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mse(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mse");
     anofox_set.AddFunction(ScalarFunction(
@@ -139,7 +171,18 @@ void RegisterTsMseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMseFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mse";
+        FunctionDescription desc;
+        desc.description = "Computes Mean Squared Error (MSE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mse(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -188,7 +231,17 @@ void RegisterTsRmseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsRmseFunction
     ));
-    loader.RegisterFunction(ts_rmse_set);
+    {
+        CreateScalarFunctionInfo info(ts_rmse_set);
+        FunctionDescription desc;
+        desc.description = "Computes Root Mean Squared Error (RMSE) between actual and predicted value arrays.";
+        desc.examples = {"ts_rmse(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_rmse");
     anofox_set.AddFunction(ScalarFunction(
@@ -196,7 +249,18 @@ void RegisterTsRmseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsRmseFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_rmse";
+        FunctionDescription desc;
+        desc.description = "Computes Root Mean Squared Error (RMSE) between actual and predicted value arrays.";
+        desc.examples = {"ts_rmse(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -245,7 +309,17 @@ void RegisterTsMapeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMapeFunction
     ));
-    loader.RegisterFunction(ts_mape_set);
+    {
+        CreateScalarFunctionInfo info(ts_mape_set);
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Percentage Error (MAPE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mape(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mape");
     anofox_set.AddFunction(ScalarFunction(
@@ -253,7 +327,18 @@ void RegisterTsMapeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMapeFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mape";
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Percentage Error (MAPE) between actual and predicted value arrays.";
+        desc.examples = {"ts_mape(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -302,7 +387,17 @@ void RegisterTsSmapeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsSmapeFunction
     ));
-    loader.RegisterFunction(ts_smape_set);
+    {
+        CreateScalarFunctionInfo info(ts_smape_set);
+        FunctionDescription desc;
+        desc.description = "Computes Symmetric Mean Absolute Percentage Error (sMAPE) between actual and predicted value arrays.";
+        desc.examples = {"ts_smape(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_smape");
     anofox_set.AddFunction(ScalarFunction(
@@ -310,7 +405,18 @@ void RegisterTsSmapeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsSmapeFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_smape";
+        FunctionDescription desc;
+        desc.description = "Computes Symmetric Mean Absolute Percentage Error (sMAPE) between actual and predicted value arrays.";
+        desc.examples = {"ts_smape(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -364,7 +470,17 @@ void RegisterTsMaseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMaseFunction
     ));
-    loader.RegisterFunction(ts_mase_set);
+    {
+        CreateScalarFunctionInfo info(ts_mase_set);
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Scaled Error (MASE) comparing forecast error to a baseline model.";
+        desc.examples = {"ts_mase(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), LIST(naive ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted", "baseline"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mase");
     anofox_set.AddFunction(ScalarFunction(
@@ -372,7 +488,18 @@ void RegisterTsMaseFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMaseFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mase";
+        FunctionDescription desc;
+        desc.description = "Computes Mean Absolute Scaled Error (MASE) comparing forecast error to a baseline model.";
+        desc.examples = {"ts_mase(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), LIST(naive ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted", "baseline"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -421,7 +548,17 @@ void RegisterTsR2Function(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsR2Function
     ));
-    loader.RegisterFunction(ts_r2_set);
+    {
+        CreateScalarFunctionInfo info(ts_r2_set);
+        FunctionDescription desc;
+        desc.description = "Computes the R-squared (coefficient of determination) between actual and predicted value arrays.";
+        desc.examples = {"ts_r2(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_r2");
     anofox_set.AddFunction(ScalarFunction(
@@ -429,7 +566,18 @@ void RegisterTsR2Function(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsR2Function
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_r2";
+        FunctionDescription desc;
+        desc.description = "Computes the R-squared (coefficient of determination) between actual and predicted value arrays.";
+        desc.examples = {"ts_r2(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -478,7 +626,17 @@ void RegisterTsBiasFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsBiasFunction
     ));
-    loader.RegisterFunction(ts_bias_set);
+    {
+        CreateScalarFunctionInfo info(ts_bias_set);
+        FunctionDescription desc;
+        desc.description = "Computes mean forecast bias (mean error) between actual and predicted value arrays.";
+        desc.examples = {"ts_bias(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_bias");
     anofox_set.AddFunction(ScalarFunction(
@@ -486,7 +644,18 @@ void RegisterTsBiasFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsBiasFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_bias";
+        FunctionDescription desc;
+        desc.description = "Computes mean forecast bias (mean error) between actual and predicted value arrays.";
+        desc.examples = {"ts_bias(LIST(actual ORDER BY date), LIST(forecast ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -541,7 +710,17 @@ void RegisterTsRmaeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsRmaeFunction
     ));
-    loader.RegisterFunction(ts_rmae_set);
+    {
+        CreateScalarFunctionInfo info(ts_rmae_set);
+        FunctionDescription desc;
+        desc.description = "Computes Relative MAE: ratio of MAE(actual, pred1) to MAE(actual, pred2). Values < 1 mean pred1 is better.";
+        desc.examples = {"ts_rmae(LIST(actual ORDER BY date), LIST(model_a ORDER BY date), LIST(model_b ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "pred1", "pred2"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_rmae");
     anofox_set.AddFunction(ScalarFunction(
@@ -549,7 +728,18 @@ void RegisterTsRmaeFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsRmaeFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_rmae";
+        FunctionDescription desc;
+        desc.description = "Computes Relative MAE: ratio of MAE(actual, pred1) to MAE(actual, pred2). Values < 1 mean pred1 is better.";
+        desc.examples = {"ts_rmae(LIST(actual ORDER BY date), LIST(model_a ORDER BY date), LIST(model_b ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "pred1", "pred2"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -609,7 +799,17 @@ void RegisterTsQuantileLossFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsQuantileLossFunction
     ));
-    loader.RegisterFunction(ts_ql_set);
+    {
+        CreateScalarFunctionInfo info(ts_ql_set);
+        FunctionDescription desc;
+        desc.description = "Computes the quantile (pinball) loss for a single quantile level.";
+        desc.examples = {"ts_quantile_loss(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), 0.9)"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted", "quantile"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_quantile_loss");
     anofox_set.AddFunction(ScalarFunction(
@@ -617,7 +817,18 @@ void RegisterTsQuantileLossFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsQuantileLossFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_quantile_loss";
+        FunctionDescription desc;
+        desc.description = "Computes the quantile (pinball) loss for a single quantile level.";
+        desc.examples = {"ts_quantile_loss(LIST(actual ORDER BY date), LIST(forecast ORDER BY date), 0.9)"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "predicted", "quantile"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -718,7 +929,17 @@ void RegisterTsMqlossFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMqlossFunction
     ));
-    loader.RegisterFunction(ts_mqloss_set);
+    {
+        CreateScalarFunctionInfo info(ts_mqloss_set);
+        FunctionDescription desc;
+        desc.description = "Computes Mean Quantile Loss (MQLoss) across multiple quantile levels.";
+        desc.examples = {"ts_mqloss(LIST(actual ORDER BY date), LIST([lower, upper] ORDER BY date), [0.1, 0.9])"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "quantiles", "levels"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_mqloss");
     anofox_set.AddFunction(ScalarFunction(
@@ -728,7 +949,18 @@ void RegisterTsMqlossFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsMqlossFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_mqloss";
+        FunctionDescription desc;
+        desc.description = "Computes Mean Quantile Loss (MQLoss) across multiple quantile levels.";
+        desc.examples = {"ts_mqloss(LIST(actual ORDER BY date), LIST([lower, upper] ORDER BY date), [0.1, 0.9])"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "quantiles", "levels"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -781,7 +1013,17 @@ void RegisterTsCoverageFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsCoverageFunction
     ));
-    loader.RegisterFunction(ts_coverage_set);
+    {
+        CreateScalarFunctionInfo info(ts_coverage_set);
+        FunctionDescription desc;
+        desc.description = "Computes the empirical coverage rate of prediction intervals: fraction of actuals within [lower, upper].";
+        desc.examples = {"ts_coverage(LIST(actual ORDER BY date), LIST(lower ORDER BY date), LIST(upper ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "lower", "upper"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_coverage");
     anofox_set.AddFunction(ScalarFunction(
@@ -789,7 +1031,18 @@ void RegisterTsCoverageFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsCoverageFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_coverage";
+        FunctionDescription desc;
+        desc.description = "Computes the empirical coverage rate of prediction intervals: fraction of actuals within [lower, upper].";
+        desc.examples = {"ts_coverage(LIST(actual ORDER BY date), LIST(lower ORDER BY date), LIST(upper ORDER BY date))"};
+        desc.categories = {"time-series", "metrics"};
+        desc.parameter_names = {"actual", "lower", "upper"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -852,7 +1105,17 @@ void RegisterTsEstimateBacktestMemoryFunction(ExtensionLoader &loader) {
         LogicalType::BIGINT,
         TsEstimateBacktestMemoryFunction
     ));
-    loader.RegisterFunction(func_set);
+    {
+        CreateScalarFunctionInfo info(func_set);
+        FunctionDescription desc;
+        desc.description = "Estimates memory usage in MB for a ts_backtest_auto_by run given series count, length, folds, and horizon.";
+        desc.examples = {"ts_estimate_backtest_memory(100, 365, 3, 30)"};
+        desc.categories = {"time-series", "utilities"};
+        desc.parameter_names = {"n_series", "n_dates", "folds", "horizon"};
+        desc.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/ts_forecast_scalar.cpp
+++ b/src/scalar_functions/ts_forecast_scalar.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include <algorithm>
 #include <cmath>
 #include <cstring>

--- a/src/table_functions/ts_aggregate_hierarchy.cpp
+++ b/src/table_functions/ts_aggregate_hierarchy.cpp
@@ -2,6 +2,7 @@
 #include "ts_fill_gaps_native.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <algorithm>
 #include <map>
 #include <vector>
@@ -444,7 +445,15 @@ void RegisterTsAggregateHierarchyFunction(ExtensionLoader &loader) {
     func.in_out_function = TsAggregateHierarchyInOut;
     func.in_out_function_final = TsAggregateHierarchyFinalize;
 
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Aggregates time series data up through a hierarchy of group keys, rolling up lower-level series to higher levels.";
+        desc.examples = {"SELECT * FROM ts_aggregate_hierarchy(TABLE(SELECT date, value, region, store, item FROM t), MAP {'separator': '|'})"};
+        desc.categories = {"time-series", "hierarchical"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_changepoints.cpp
+++ b/src/table_functions/ts_changepoints.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include <map>
 #include <mutex>

--- a/src/table_functions/ts_combine_keys.cpp
+++ b/src/table_functions/ts_combine_keys.cpp
@@ -2,6 +2,7 @@
 #include "ts_fill_gaps_native.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <vector>
 
 namespace duckdb {
@@ -219,7 +220,15 @@ void RegisterTsCombineKeysFunction(ExtensionLoader &loader) {
     // Set up as table-in-out function
     func.in_out_function = TsCombineKeysInOut;
 
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Combines multiple group key columns into a single composite key column for multi-key time series operations.";
+        desc.examples = {"SELECT * FROM ts_combine_keys(TABLE(SELECT date, value, region, store FROM t), MAP {'separator': '|'})"};
+        desc.categories = {"time-series", "hierarchical"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_data_quality.cpp
+++ b/src/table_functions/ts_data_quality.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/table_functions/ts_decomposition.cpp
+++ b/src/table_functions/ts_decomposition.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include <algorithm>
 #include <cctype>
 

--- a/src/table_functions/ts_detrend.cpp
+++ b/src/table_functions/ts_detrend.cpp
@@ -3,6 +3,8 @@
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -126,7 +128,17 @@ void RegisterTsDetrendFunction(ExtensionLoader &loader) {
         GetDetrendResultType(),
         TsDetrendFunction
     ));
-    loader.RegisterFunction(ts_detrend_set);
+    {
+        CreateScalarFunctionInfo info(ts_detrend_set);
+        FunctionDescription desc;
+        desc.description = "Removes the trend component from a time series using linear or seasonal decomposition, returning detrended values.";
+        desc.examples = {"ts_detrend(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "decomposition"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -230,7 +242,17 @@ void RegisterTsDecomposeSeasonalFunction(ExtensionLoader &loader) {
         GetDecomposeResultType(),
         TsDecomposeSeasonalFunction
     ));
-    loader.RegisterFunction(ts_decompose_set);
+    {
+        CreateScalarFunctionInfo info(ts_decompose_set);
+        FunctionDescription desc;
+        desc.description = "Extracts the seasonal component from a time series, returning seasonal indices or adjusted values.";
+        desc.examples = {"ts_decompose_seasonal(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "decomposition"};
+        desc.parameter_names = {"values", "period"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -303,7 +325,17 @@ void RegisterTsSeasonalStrengthFunction(ExtensionLoader &loader) {
         LogicalType(LogicalTypeId::DOUBLE),
         TsSeasonalStrengthFunction
     ));
-    loader.RegisterFunction(ts_strength_set);
+    {
+        CreateScalarFunctionInfo info(ts_strength_set);
+        FunctionDescription desc;
+        desc.description = "Computes the seasonal strength metric (0-1) indicating how strongly seasonal patterns dominate the time series.";
+        desc.examples = {"ts_seasonal_strength(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "decomposition", "seasonality"};
+        desc.parameter_names = {"values", "period"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -400,7 +432,17 @@ void RegisterTsSeasonalStrengthWindowedFunction(ExtensionLoader &loader) {
         LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)),
         TsSeasonalStrengthWindowedFunction
     ));
-    loader.RegisterFunction(ts_strength_win_set);
+    {
+        CreateScalarFunctionInfo info(ts_strength_win_set);
+        FunctionDescription desc;
+        desc.description = "Computes rolling seasonal strength over a sliding window, returning strength estimates per window position.";
+        desc.examples = {"ts_seasonal_strength_windowed(LIST(value ORDER BY date), 7, 52)"};
+        desc.categories = {"time-series", "decomposition", "seasonality"};
+        desc.parameter_names = {"values", "period", "window_size"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -553,7 +595,17 @@ void RegisterTsDetectSeasonalityChangesFunction(ExtensionLoader &loader) {
         GetChangeDetectionResultType(),
         TsDetectSeasonalityChangesFunction
     ));
-    loader.RegisterFunction(ts_changes_set);
+    {
+        CreateScalarFunctionInfo info(ts_changes_set);
+        FunctionDescription desc;
+        desc.description = "Detects structural changes in seasonal patterns over time, returning periods where seasonality changes significantly.";
+        desc.examples = {"ts_detect_seasonality_changes(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values", "period"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -636,7 +688,17 @@ void RegisterTsInstantaneousPeriodFunction(ExtensionLoader &loader) {
         GetInstantaneousPeriodResultType(),
         TsInstantaneousPeriodFunction
     ));
-    loader.RegisterFunction(ts_inst_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_inst_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the instantaneous period of a time series using the Hilbert transform analytic signal method. Returns STRUCT(periods[], frequencies[], amplitudes[]).";
+        desc.examples = {"ts_instantaneous_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -761,7 +823,17 @@ void RegisterTsDetectAmplitudeModulationFunction(ExtensionLoader &loader) {
         GetAmplitudeModulationResultType(),
         TsDetectAmplitudeModulationFunction
     ));
-    loader.RegisterFunction(ts_am_set);
+    {
+        CreateScalarFunctionInfo info(ts_am_set);
+        FunctionDescription desc;
+        desc.description = "Detects amplitude modulation in a seasonal time series, identifying whether peak amplitudes vary significantly over time. Returns STRUCT with modulation type, score, and amplitude trend.";
+        desc.examples = {"ts_detect_amplitude_modulation(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values", "period"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_features.cpp
+++ b/src/table_functions/ts_features.cpp
@@ -4,6 +4,9 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include <unordered_map>
 #include <limits>
 
@@ -227,7 +230,15 @@ static void TsFeaturesListExecute(ClientContext &context, TableFunctionInput &da
 
 void RegisterTsFeaturesListFunction(ExtensionLoader &loader) {
     TableFunction ts_features_list_func("ts_features_list", {}, TsFeaturesListExecute, TsFeaturesListBind);
-    loader.RegisterFunction(ts_features_list_func);
+    {
+        CreateTableFunctionInfo info(ts_features_list_func);
+        FunctionDescription desc;
+        desc.description = "Returns a table listing all 117 available tsfresh-compatible feature names and their categories.";
+        desc.examples = {"SELECT * FROM ts_features_list()"};
+        desc.categories = {"time-series", "feature-extraction"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -294,7 +305,15 @@ static void TsFeaturesConfigTemplateExecute(ClientContext &context, TableFunctio
 
 void RegisterTsFeaturesConfigTemplateFunction(ExtensionLoader &loader) {
     TableFunction func("ts_features_config_template", {}, TsFeaturesConfigTemplateExecute, TsFeaturesConfigTemplateBind);
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Returns a JSON template for configuring which features to compute with ts_features_by().";
+        desc.examples = {"SELECT * FROM ts_features_config_template()"};
+        desc.categories = {"time-series", "feature-extraction"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -377,7 +396,17 @@ void RegisterTsFeaturesConfigFromJsonFunction(ExtensionLoader &loader) {
         GetFeaturesConfigResultType(),
         TsFeaturesConfigFromJsonFunction
     ));
-    loader.RegisterFunction(config_json_set);
+    {
+        CreateScalarFunctionInfo info(config_json_set);
+        FunctionDescription desc;
+        desc.description = "Parses a feature configuration JSON string for use with ts_features_by() to select specific features.";
+        desc.examples = {"ts_features_config_from_json('{\"features\": [\"mean\", \"std\"]}')"};
+        desc.categories = {"time-series", "feature-extraction"};
+        desc.parameter_names = {"config_json"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::VARCHAR)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_features_config_from_json");
     anofox_set.AddFunction(ScalarFunction(
@@ -385,7 +414,18 @@ void RegisterTsFeaturesConfigFromJsonFunction(ExtensionLoader &loader) {
         GetFeaturesConfigResultType(),
         TsFeaturesConfigFromJsonFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_features_config_from_json";
+        FunctionDescription desc;
+        desc.description = "Parses a feature configuration JSON string for use with ts_features_by() to select specific features.";
+        desc.examples = {"ts_features_config_from_json('{\"features\": [\"mean\", \"std\"]}')"};
+        desc.categories = {"time-series", "feature-extraction"};
+        desc.parameter_names = {"config_json"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::VARCHAR)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -405,7 +445,17 @@ void RegisterTsFeaturesConfigFromCsvFunction(ExtensionLoader &loader) {
         GetFeaturesConfigResultType(),
         TsFeaturesConfigFromCsvFunction
     ));
-    loader.RegisterFunction(config_csv_set);
+    {
+        CreateScalarFunctionInfo info(config_csv_set);
+        FunctionDescription desc;
+        desc.description = "Parses a CSV string of feature names into a feature configuration for use with ts_features_by().";
+        desc.examples = {"ts_features_config_from_csv('mean,std,skewness')"};
+        desc.categories = {"time-series", "feature-extraction"};
+        desc.parameter_names = {"config_csv"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::VARCHAR)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_features_config_from_csv");
     anofox_set.AddFunction(ScalarFunction(
@@ -413,7 +463,18 @@ void RegisterTsFeaturesConfigFromCsvFunction(ExtensionLoader &loader) {
         GetFeaturesConfigResultType(),
         TsFeaturesConfigFromCsvFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_features_config_from_csv";
+        FunctionDescription desc;
+        desc.description = "Parses a CSV string of feature names into a feature configuration for use with ts_features_by().";
+        desc.examples = {"ts_features_config_from_csv('mean,std,skewness')"};
+        desc.categories = {"time-series", "feature-extraction"};
+        desc.parameter_names = {"config_csv"};
+        desc.parameter_types = {LogicalType(LogicalTypeId::VARCHAR)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_fill_forward_operator.cpp
+++ b/src/table_functions/ts_fill_forward_operator.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
 #include <algorithm>
 #include <map>
@@ -191,12 +192,29 @@ void RegisterTsFillForwardOperatorFunction(ExtensionLoader &loader) {
         TsFillForwardOperatorInitGlobal,
         TsFillForwardOperatorInitLocal);
 
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Native table function: forward-fills NULL values in time series within groups. Used internally by ts_fill_forward_by().";
+        desc.examples = {"SELECT * FROM ts_fill_forward_operator(source_table, group_col, date_col, value_col, target_date, frequency)"};
+        desc.categories = {"time-series", "data-preparation"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register with anofox_fcst prefix for API compatibility
     TableFunction anofox_func = func;
     anofox_func.name = "anofox_fcst_ts_fill_forward_operator";
-    loader.RegisterFunction(anofox_func);
+    {
+        CreateTableFunctionInfo anofox_info(anofox_func);
+        anofox_info.alias_of = "ts_fill_forward_operator";
+        FunctionDescription desc;
+        desc.description = "Native table function: forward-fills NULL values in time series within groups. Used internally by ts_fill_forward_by().";
+        desc.examples = {"SELECT * FROM anofox_fcst_ts_fill_forward_operator(source_table, group_col, date_col, value_col, target_date, frequency)"};
+        desc.categories = {"time-series", "data-preparation"};
+        anofox_info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(anofox_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_filter.cpp
+++ b/src/table_functions/ts_filter.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/table_functions/ts_forecast.cpp
+++ b/src/table_functions/ts_forecast.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/table_functions/ts_imputation.cpp
+++ b/src/table_functions/ts_imputation.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 

--- a/src/table_functions/ts_peaks.cpp
+++ b/src/table_functions/ts_peaks.cpp
@@ -3,6 +3,8 @@
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -177,7 +179,17 @@ void RegisterTsDetectPeaksFunction(ExtensionLoader &loader) {
         GetPeakDetectionResultType(),
         TsDetectPeaksFunction
     ));
-    loader.RegisterFunction(ts_peaks_set);
+    {
+        CreateScalarFunctionInfo info(ts_peaks_set);
+        FunctionDescription desc;
+        desc.description = "Detects peaks in a time series array using prominence-based peak finding. Returns STRUCT with peak indices and properties.";
+        desc.examples = {"ts_detect_peaks(LIST(value ORDER BY date))", "ts_detect_peaks(LIST(value ORDER BY date), MAP{'min_prominence': '0.5'})"};
+        desc.categories = {"time-series", "peak-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -280,7 +292,17 @@ void RegisterTsAnalyzePeakTimingFunction(ExtensionLoader &loader) {
         GetPeakTimingResultType(),
         TsAnalyzePeakTimingFunction
     ));
-    loader.RegisterFunction(ts_peak_timing_set);
+    {
+        CreateScalarFunctionInfo info(ts_peak_timing_set);
+        FunctionDescription desc;
+        desc.description = "Analyzes timing patterns of peaks detected by ts_detect_peaks, returning periodicity and phase statistics.";
+        desc.examples = {"ts_analyze_peak_timing(LIST(value ORDER BY date), LIST(date ORDER BY date))"};
+        desc.categories = {"time-series", "peak-detection"};
+        desc.parameter_names = {"values", "period"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE)), LogicalType(LogicalTypeId::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_periods.cpp
+++ b/src/table_functions/ts_periods.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -533,7 +534,17 @@ void RegisterTsEstimatePeriodFftFunction(ExtensionLoader &loader) {
     // Disable constant folding for this function - struct returns don't work well with it
     fft_func.stability = FunctionStability::VOLATILE;
     ts_period_fft_set.AddFunction(fft_func);
-    loader.RegisterFunction(ts_period_fft_set);
+    {
+        CreateScalarFunctionInfo info(ts_period_fft_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the dominant seasonal period using Fast Fourier Transform spectral analysis.";
+        desc.examples = {"ts_estimate_period_fft(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -606,7 +617,17 @@ void RegisterTsEstimatePeriodAcfFunction(ExtensionLoader &loader) {
     );
     acf_func2.stability = FunctionStability::VOLATILE;
     ts_period_acf_set.AddFunction(acf_func2);
-    loader.RegisterFunction(ts_period_acf_set);
+    {
+        CreateScalarFunctionInfo info(ts_period_acf_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using the Autocorrelation Function (ACF) by finding the lag of maximum autocorrelation.";
+        desc.examples = {"ts_estimate_period_acf(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -799,7 +820,17 @@ void RegisterTsDetectMultiplePeriodsFunction(ExtensionLoader &loader) {
     );
     func4.stability = FunctionStability::VOLATILE;
     ts_multi_periods_set.AddFunction(func4);
-    loader.RegisterFunction(ts_multi_periods_set);
+    {
+        CreateScalarFunctionInfo info(ts_multi_periods_set);
+        FunctionDescription desc;
+        desc.description = "Detects multiple seasonal periods simultaneously, returning a ranked list of period candidates with confidence scores.";
+        desc.examples = {"ts_detect_multiple_periods(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -882,7 +913,17 @@ void RegisterTsAutoperiodFunction(ExtensionLoader &loader) {
     );
     func2.stability = FunctionStability::VOLATILE;
     ts_autoperiod_set.AddFunction(func2);
-    loader.RegisterFunction(ts_autoperiod_set);
+    {
+        CreateScalarFunctionInfo info(ts_autoperiod_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using the Autoperiod algorithm combining FFT and autocorrelation.";
+        desc.examples = {"ts_autoperiod(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -955,7 +996,17 @@ void RegisterTsCfdAutoperiodFunction(ExtensionLoader &loader) {
     );
     func2.stability = FunctionStability::VOLATILE;
     ts_cfd_autoperiod_set.AddFunction(func2);
-    loader.RegisterFunction(ts_cfd_autoperiod_set);
+    {
+        CreateScalarFunctionInfo info(ts_cfd_autoperiod_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using Conditional Frequency Distribution (CFD) autoperiod method.";
+        desc.examples = {"ts_cfd_autoperiod(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -1069,7 +1120,17 @@ void RegisterTsLombScargleFunction(ExtensionLoader &loader) {
     );
     func4.stability = FunctionStability::VOLATILE;
     ts_lomb_scargle_set.AddFunction(func4);
-    loader.RegisterFunction(ts_lomb_scargle_set);
+    {
+        CreateScalarFunctionInfo info(ts_lomb_scargle_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the dominant period using the Lomb-Scargle periodogram, suitable for unevenly-sampled time series.";
+        desc.examples = {"ts_lomb_scargle(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -1180,7 +1241,17 @@ void RegisterTsAicPeriodFunction(ExtensionLoader &loader) {
     );
     func4.stability = FunctionStability::VOLATILE;
     ts_aic_period_set.AddFunction(func4);
-    loader.RegisterFunction(ts_aic_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_aic_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period by minimizing the Akaike Information Criterion (AIC) over candidate periods.";
+        desc.examples = {"ts_aic_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -1275,7 +1346,17 @@ void RegisterTsSsaPeriodFunction(ExtensionLoader &loader) {
     );
     func3.stability = FunctionStability::VOLATILE;
     ts_ssa_period_set.AddFunction(func3);
-    loader.RegisterFunction(ts_ssa_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_ssa_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using Singular Spectrum Analysis (SSA).";
+        desc.examples = {"ts_ssa_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // =============================================================================
@@ -1382,7 +1463,17 @@ void RegisterTsStlPeriodFunction(ExtensionLoader &loader) {
     );
     func4.stability = FunctionStability::VOLATILE;
     ts_stl_period_set.AddFunction(func4);
-    loader.RegisterFunction(ts_stl_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_stl_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using Seasonal and Trend decomposition using Loess (STL).";
+        desc.examples = {"ts_stl_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // =============================================================================
@@ -1479,7 +1570,17 @@ void RegisterTsMatrixProfilePeriodFunction(ExtensionLoader &loader) {
     );
     func3.stability = FunctionStability::VOLATILE;
     ts_mp_period_set.AddFunction(func3);
-    loader.RegisterFunction(ts_mp_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_mp_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using Matrix Profile motif discovery.";
+        desc.examples = {"ts_matrix_profile_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // =============================================================================
@@ -1586,7 +1687,17 @@ void RegisterTsSazedPeriodFunction(ExtensionLoader &loader) {
     );
     func4.stability = FunctionStability::VOLATILE;
     ts_sazed_period_set.AddFunction(func4);
-    loader.RegisterFunction(ts_sazed_period_set);
+    {
+        CreateScalarFunctionInfo info(ts_sazed_period_set);
+        FunctionDescription desc;
+        desc.description = "Estimates the seasonal period using the SAZED (Self-Adaptive Zero-crossing Estimation of Dominant period) algorithm.";
+        desc.examples = {"ts_sazed_period(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "period-detection"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_seasonality.cpp
+++ b/src/table_functions/ts_seasonality.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/types/vector.hpp"
 
 namespace duckdb {
 
@@ -92,7 +94,17 @@ void RegisterTsDetectSeasonalityFunction(ExtensionLoader &loader) {
         LogicalType::LIST(LogicalType(LogicalTypeId::INTEGER)),
         TsDetectSeasonalityFunction
     ));
-    loader.RegisterFunction(ts_detect_set);
+    {
+        CreateScalarFunctionInfo info(ts_detect_set);
+        FunctionDescription desc;
+        desc.description = "Tests whether a time series exhibits statistically significant seasonality. Returns TRUE/FALSE or a confidence score.";
+        desc.examples = {"ts_detect_seasonality(LIST(value ORDER BY date))", "ts_detect_seasonality(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_detect_seasonality");
     anofox_set.AddFunction(ScalarFunction(
@@ -100,7 +112,18 @@ void RegisterTsDetectSeasonalityFunction(ExtensionLoader &loader) {
         LogicalType::LIST(LogicalType(LogicalTypeId::INTEGER)),
         TsDetectSeasonalityFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_detect_seasonality";
+        FunctionDescription desc;
+        desc.description = "Tests whether a time series exhibits statistically significant seasonality. Returns TRUE/FALSE or a confidence score.";
+        desc.examples = {"ts_detect_seasonality(LIST(value ORDER BY date))"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -263,7 +286,24 @@ void RegisterTsAnalyzeSeasonalityFunction(ExtensionLoader &loader) {
         GetSeasonalityResultType(),
         TsAnalyzeSeasonalityWithTimestampsFunction
     ));
-    loader.RegisterFunction(ts_analyze_set);
+    {
+        CreateScalarFunctionInfo info(ts_analyze_set);
+        FunctionDescription desc;
+        desc.description = "Analyzes seasonal patterns in detail, returning amplitude, phase, strength, and period information.";
+        desc.examples = {"ts_analyze_seasonality(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        FunctionDescription desc2;
+        desc2.description = "Analyzes seasonal patterns in detail, returning amplitude, phase, strength, and period information.";
+        desc2.examples = {"ts_analyze_seasonality(LIST(ts ORDER BY ts), LIST(value ORDER BY ts))"};
+        desc2.categories = {"time-series", "seasonality"};
+        desc2.parameter_names = {"timestamps", "values"};
+        desc2.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::TIMESTAMP)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ScalarFunctionSet anofox_set("anofox_fcst_ts_analyze_seasonality");
     anofox_set.AddFunction(ScalarFunction(
@@ -276,7 +316,25 @@ void RegisterTsAnalyzeSeasonalityFunction(ExtensionLoader &loader) {
         GetSeasonalityResultType(),
         TsAnalyzeSeasonalityWithTimestampsFunction
     ));
-    loader.RegisterFunction(anofox_set);
+    {
+        CreateScalarFunctionInfo info(anofox_set);
+        info.alias_of = "ts_analyze_seasonality";
+        FunctionDescription desc;
+        desc.description = "Analyzes seasonal patterns in detail, returning amplitude, phase, strength, and period information.";
+        desc.examples = {"ts_analyze_seasonality(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        FunctionDescription desc2;
+        desc2.description = "Analyzes seasonal patterns in detail, returning amplitude, phase, strength, and period information.";
+        desc2.examples = {"ts_analyze_seasonality(LIST(ts ORDER BY ts), LIST(value ORDER BY ts))"};
+        desc2.categories = {"time-series", "seasonality"};
+        desc2.parameter_names = {"timestamps", "values"};
+        desc2.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::TIMESTAMP)), LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 // ============================================================================
@@ -469,7 +527,17 @@ void RegisterTsClassifySeasonalityFunction(ExtensionLoader &loader) {
         TsClassifySeasonalityFunction
     ));
 
-    loader.RegisterFunction(ts_classify_set);
+    {
+        CreateScalarFunctionInfo info(ts_classify_set);
+        FunctionDescription desc;
+        desc.description = "Classifies the seasonality type (timing and modulation) of a time series, returning timing_classification, modulation_type, and seasonal strength.";
+        desc.examples = {"ts_classify_seasonality(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register with anofox_ prefix
     ScalarFunctionSet anofox_classify_set("anofox_fcst_ts_classify_seasonality");
@@ -488,7 +556,18 @@ void RegisterTsClassifySeasonalityFunction(ExtensionLoader &loader) {
         GetSeasonalityClassificationResultType(),
         TsClassifySeasonalityFunction
     ));
-    loader.RegisterFunction(anofox_classify_set);
+    {
+        CreateScalarFunctionInfo info(anofox_classify_set);
+        info.alias_of = "ts_classify_seasonality";
+        FunctionDescription desc;
+        desc.description = "Classifies the seasonality type (timing and modulation) of a time series, returning timing_classification, modulation_type, and seasonal strength.";
+        desc.examples = {"ts_classify_seasonality(LIST(value ORDER BY date), 7)"};
+        desc.categories = {"time-series", "seasonality"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType(LogicalTypeId::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_split_keys.cpp
+++ b/src/table_functions/ts_split_keys.cpp
@@ -2,6 +2,7 @@
 #include "ts_fill_gaps_native.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <vector>
 #include <sstream>
 #include <mutex>
@@ -414,7 +415,15 @@ void RegisterTsSplitKeysFunction(ExtensionLoader &loader) {
     func.in_out_function = TsSplitKeysInOut;
     func.in_out_function_final = TsSplitKeysFinalize;
 
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Splits a composite group key column back into its original multiple key columns.";
+        desc.examples = {"SELECT * FROM ts_split_keys(TABLE(SELECT unique_id, date, value FROM t), separator='|', columns=['region', 'store', 'item'])"};
+        desc.categories = {"time-series", "hierarchical"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ts_stats.cpp
+++ b/src/table_functions/ts_stats.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include <regex>
 #include <map>

--- a/src/table_functions/ts_validate_separator.cpp
+++ b/src/table_functions/ts_validate_separator.cpp
@@ -1,6 +1,7 @@
 #include "ts_validate_separator.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <set>
 #include <vector>
 #include <mutex>
@@ -278,7 +279,15 @@ void RegisterTsValidateSeparatorFunction(ExtensionLoader &loader) {
     func.in_out_function = TsValidateSeparatorInOut;
     func.in_out_function_final = TsValidateSeparatorFinalize;
 
-    loader.RegisterFunction(func);
+    {
+        CreateTableFunctionInfo info(func);
+        FunctionDescription desc;
+        desc.description = "Validates that group key separators in composite keys are consistent and non-ambiguous.";
+        desc.examples = {"SELECT * FROM ts_validate_separator(TABLE(SELECT region, store FROM t), separator='|')"};
+        desc.categories = {"time-series", "utilities"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## Summary

- Populates `description`, `examples`, `categories`, `parameter_names`, `parameter_types`, and `alias_of` for every public-facing function so that `SELECT * FROM duckdb_functions()` returns complete documentation
- All `anofox_fcst_*` registrations set `alias_of` to the primary `ts_*` function name
- Table macros populate `MacroFunction::types` with `LogicalType::ANY` so `parameter_types` shows `ANY` instead of NULL
- SQL table macros in `ts_macros.cpp` extended with description, example, and category fields (65 macros × 2 aliases = 130 entries)

## Coverage (verified at runtime)

| function_type | total | has description | has return_type | has parameter_types | has alias_of |
|---|---|---|---|---|---|
| aggregate | 23 | 23 | 23 | 23 | 10 (`anofox_fcst_*`) |
| scalar | 120 | 120 | 120 | 120 | 32 (`anofox_fcst_*`) |
| table | 8 | 8 | 0* | 8 | 1 (`anofox_fcst_*`) |
| table_macro | 130 | 130 | 0* | 130 | 65 (`anofox_fcst_*`) |

\* `return_type` is NULL for `table` and `table_macro` — DuckDB hardcodes this in `TableFunctionExtractor::GetReturnType` and `TableMacroExtractor::GetReturnType`. It is auto-populated for scalar/aggregate from function definitions.

## Test plan

- [ ] Build succeeds: `make`
- [ ] Verify coverage query:
  ```sql
  LOAD anofox_forecast;
  SELECT function_type, count(*) as total, count(description) as has_desc,
         count(alias_of) as has_alias, count(parameter_types) as has_ptypes
  FROM duckdb_functions()
  WHERE function_name LIKE 'ts_%' OR function_name LIKE 'anofox_fcst_%'
  GROUP BY function_type ORDER BY function_type;
  ```
- [ ] Spot-check a specific function:
  ```sql
  SELECT function_name, alias_of, description, examples, categories, parameter_types
  FROM duckdb_functions() WHERE function_name = 'ts_forecast_agg';
  ```