### PR TITLE
Bundle OpenSSL via vcpkg (fixes #215)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,13 +121,11 @@ elseif(APPLE AND DEFINED OSX_BUILD_ARCH AND NOT "${OSX_BUILD_ARCH}" STREQUAL "${
 endif()
 
 if(TELEMETRY_SUPPORTED)
-    # Static OpenSSL on Linux/macOS avoids a runtime dependency on libssl.so.1.1,
-    # which is no longer available on Ubuntu 22.04+, Fedora 36+, Arch, etc. (issue #211).
-    # Skip on Windows: vcpkg's x64-windows-static-release triplet already handles
-    # bundling, and forcing static here causes a CRT mismatch (LNK2019 on __imp_fgets etc.).
-    if(NOT WIN32)
-        set(OPENSSL_USE_STATIC_LIBS ON)
-    endif()
+    # Static OpenSSL avoids runtime dependencies on libssl.so.1.1 (Linux, issue #211)
+    # and libssl-3-x64.dll / libcrypto-3-x64.dll (Windows, issue #215). On Windows this
+    # requires `openssl` in vcpkg.json so the x64-windows-static-release triplet
+    # supplies static libs built with /MT (matching the extension's CRT).
+    set(OPENSSL_USE_STATIC_LIBS ON)
     find_package(OpenSSL QUIET)
     if(OPENSSL_FOUND)
         set(DUCKDB_SRC_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/duckdb/src/include")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,3 +1,5 @@
 {
-  "dependencies": []
+  "dependencies": [
+    "openssl"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `openssl` to `vcpkg.json` so the `x64-windows-static-release` triplet supplies static OpenSSL libs.
- Re-enable `OPENSSL_USE_STATIC_LIBS ON` on Windows (no longer scoped to non-Windows).

## Root cause

The Windows binary dynamically depended on `libssl-3-x64.dll` and `libcrypto-3-x64.dll` (confirmed via `objdump -p` on the published artifact). End users get "specified module not found" — the GHA `windows-latest` runner has those DLLs from Strawberry Perl / Chocolatey, but a clean Windows 11 install does not.

`vcpkg.json` had `"dependencies": []`, so the `x64-windows-static-release` triplet was never asked to install OpenSSL. CMake's `find_package(OpenSSL)` fell back to the system install with dynamic linkage. PR #214 left the static-link flag scoped to non-Windows because forcing static against the system OpenSSL produced an LNK2019 CRT mismatch — that goes away once vcpkg supplies static libs built with /MT.

## Test plan
- [x] CMake change is straightforward — same pattern as Linux
- [ ] CI green on linux_amd64, linux_arm64, macOS, WASM, **Windows**
- [ ] Reporter can verify the resulting Windows binary loads on a clean machine

Fixes #215
Related: #211, #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)