### PR TITLE
Fix stale column names in README and ts_forecast_by tests (fixes #216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ SELECT
     f.item_id,
     f.model_name,
     f.item_id || '|' || f.model_name AS series_key,
-    f.date,
+    f.ds,
     t.y AS actual,
-    f.point_forecast AS forecast
+    f.yhat AS forecast
 FROM forecast_results f
-JOIN m5_test t ON f.item_id = t.item_id AND f.date = t.ds;
+JOIN m5_test t ON f.item_id = t.item_id AND f.ds = t.ds;
 
 -- MAE and Bias per series using _by pattern
 CREATE OR REPLACE TABLE evaluation_results AS
@@ -147,8 +147,8 @@ SELECT
     split_part(m.id, '|', 2) AS model_name,
     m.mae,
     b.bias
-FROM ts_mae_by('forecast_vs_actual', series_key, date, actual, forecast) m
-JOIN ts_bias_by('forecast_vs_actual', series_key, date, actual, forecast) b
+FROM ts_mae_by('forecast_vs_actual', series_key, ds, actual, forecast) m
+JOIN ts_bias_by('forecast_vs_actual', series_key, ds, actual, forecast) b
   ON m.id = b.id;
 
 -- Summarise evaluation results by model

--- a/docs/api/02-hierarchical.md
+++ b/docs/api/02-hierarchical.md
@@ -266,15 +266,15 @@ ts_split_keys(
 ```sql
 -- Default column names (id_part_1, id_part_2, id_part_3)
 SELECT * FROM ts_split_keys(
-    (SELECT unique_id, forecast_date, yhat FROM forecasts)
+    (SELECT unique_id, ds, yhat FROM forecasts)
 );
 
 -- With custom column names
 SELECT * FROM ts_split_keys(
-    (SELECT unique_id, forecast_date, yhat FROM forecasts),
+    (SELECT unique_id, ds, yhat FROM forecasts),
     columns := ['region_id', 'store_id', 'item_id']
 );
--- Returns: region_id, store_id, item_id, forecast_date, yhat
+-- Returns: region_id, store_id, item_id, ds, yhat
 
 -- Custom separator
 SELECT * FROM ts_split_keys(

--- a/test/sql/ts_forecast_by.test
+++ b/test/sql/ts_forecast_by.test
@@ -68,7 +68,7 @@ SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1
 # Test output has expected columns
 query I
 SELECT COUNT(*) FROM (
-    SELECT id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name, insample_fitted
+    SELECT id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name
     FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
 );
 ----
@@ -546,13 +546,6 @@ query I
 SELECT MAX(forecast_step) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 5, '1d', MAP([], []));
 ----
 5
-
-# Test insample_fitted is returned as array
-query I
-SELECT COUNT(*) FROM ts_forecast_by('test_groups', id, ds, value, 'Naive', 3, '1d', MAP([], []))
-WHERE insample_fitted IS NOT NULL;
-----
-6
 
 #######################################
 # Edge Cases


### PR DESCRIPTION
## Summary
- Update README quick-start example to use the current `ts_forecast_by` schema (`ds` / `yhat` instead of `date` / `point_forecast`).
- Drop two `insample_fitted` references from `test/sql/ts_forecast_by.test` — that column is no longer returned by the table-form `ts_forecast_by`.

## Why
PR #209 reworked `ts_forecast_by` to use `_ts_forecast_scalar` for parallel execution. The new output schema is `id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name` — `insample_fitted` was removed, and the column names changed from `date` / `point_forecast` (the old `_ts_forecast_native` schema) to `ds` / `yhat`. Docs and a couple of tests weren't updated.

`insample_fitted` is still available via `ts_forecast_agg(...).insample_fitted` — only the table-form `ts_forecast_by` lost it.

## Test plan
- [x] Verified `SELECT id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name FROM ts_forecast_by(...)` returns the expected count (6 for the test fixture).
- [x] README schema matches `DESCRIBE ts_forecast_by(...)` output: `id, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name`.
- [ ] CI runs the full test suite.

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)