### PR TITLE
Force C++17 globally to fix arm64 plan_serializer link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
 
 set(CORROSION_VERBOSE_OUTPUT ON)
-set(CMAKE_CXX_STANDARD 17)
+# Force C++17 globally (CACHE FORCE) so DuckDB's submodule build picks it up too.
+# Without this, DuckDB's CMake sets CMAKE_CXX_STANDARD 11 and the static constexpr
+# class-type member duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS gets emitted as
+# a strong symbol in multiple translation units, breaking the plan_serializer link
+# on arm64 / GCC 14 (duckdb/duckdb#22097). In C++17 the member is implicitly inline.
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to enforce" FORCE)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Get installed Rust targets


### PR DESCRIPTION
## Summary

Adds `CACHE STRING "..." FORCE` to the top-level `set(CMAKE_CXX_STANDARD 17 ...)` so the C++17 setting overrides DuckDB's internal `CMAKE_CXX_STANDARD 11` when the submodule's CMake runs.

## Why

The community-extensions arm64 build (gcc-toolset-14) fails when linking `tools/plan_serializer`:

```
ld: src/libduckdb_static.a(ub_duckdb_common_serializer.cpp.o):
  multiple definition of `duckdb::BufferedFileWriter::DEFAULT_OPEN_FLAGS';
  tools/CMakeFiles/plan_serializer.dir/utils/plan_serializer.cpp.o:
  first defined here
```

`DEFAULT_OPEN_FLAGS` is declared `static constexpr` in a header. In C++11/14 that's *not* implicitly inline, so each TU that includes the header gets its own strong definition. In C++17 it *is* implicitly inline.

DuckDB's upstream fix (duckdb/duckdb#22100, merged into v1.5.3) wraps `plan_serializer` in `if(BUILD_SHELL)`. That only helps extension-only builds — community-extensions sets `BUILD_SHELL=ON` so `plan_serializer` still gets built and still hits the conflict.

[Mytherin recommended](https://github.com/duckdb/duckdb/issues/22097) the workaround of forcing C++17 globally from the consuming extension. Reference: [`ahuarte47/duckdb-pdal`](https://github.com/ahuarte47/duckdb-pdal) uses the same pattern.

## Test plan
- [x] Clean local build with `GEN=ninja make`
- [x] `tools/plan_serializer` links successfully (the previously-failing target)
- [x] DuckDB shell still reports v1.5.3
- [x] `ts_forecast()` smoke test passes
- [x] `ldd` confirms OpenSSL is still statically linked
- [ ] community-extensions CI passes on arm64 + amd64 (will verify by re-bumping the description.yml ref in duckdb/community-extensions#1951)

Related: duckdb/duckdb#22097, duckdb/duckdb#22100

🤖 Generated with [Claude Code](https://claude.com/claude-code)