### PR TITLE
docs: fix README ToC + getting-started SQL examples (#224, #225, #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ A time series forecasting extension for DuckDB with 32 models, data preparation,
 
 ## 📋 Table of Contents
 
+- [Key Features](#-key-features)
 - [Installation](#installation)
-- [Multi-Language Support](#multi-language-support)
-- [API Reference](#api-reference)
-- [Guides](#guides)
-- [License](#license)
+- [Quick Start on M5 Dataset](#-quick-start-on-m5-dataset)
+- [Multi-Language Support](#-multi-language-support)
+- [API Reference](#-api-reference)
+- [Development](#-development)
+- [License](#-license)
 
 
 ## Attribution

--- a/docs/guides/01-getting-started.md
+++ b/docs/guides/01-getting-started.md
@@ -6,7 +6,7 @@
 - Install and load the extension in DuckDB
 - Run your first forecast with sample data
 - Understand time series data structure (group, date, value)
-- Choose between three API styles (table macros, scalar functions, aggregates)
+- Choose between three API styles (table macros, table functions, aggregates)
 - Learn essential patterns for grouped forecasting
 
 ## Installation
@@ -15,6 +15,11 @@
 -- Install from DuckDB Community Extensions
 INSTALL anofox_forecast FROM community;
 LOAD anofox_forecast;
+
+-- The json extension is required for a few workflows (period detection,
+-- backtesting). Enable auto-load so it comes up on demand:
+SET autoinstall_known_extensions = 1;
+SET autoload_known_extensions = 1;
 ```
 
 ## Your First Forecast
@@ -30,10 +35,10 @@ FROM generate_series(0, 99) AS t(i);
 
 -- Generate 14-day forecasts for each product
 SELECT * FROM ts_forecast_by(
-    'sales',           -- table name
-    product_id,        -- group column
-    date,              -- date column
-    quantity,          -- value column
+    'sales',           -- table name (quoted string)
+    product_id,        -- group column (unquoted identifier)
+    date,              -- date column (unquoted identifier)
+    quantity,          -- value column (unquoted identifier)
     'AutoETS',         -- forecasting model
     14,                -- forecast horizon
     '1d'               -- frequency: daily
@@ -57,9 +62,8 @@ The extension offers three ways to work with data:
 -- 1. Table Macros (recommended for most cases)
 SELECT * FROM ts_forecast_by('sales', product_id, date, quantity, 'AutoETS', 12, '1d');
 
--- 2. Scalar Functions (for array operations)
-SELECT product_id, ts_stats(LIST(quantity ORDER BY date)) AS stats
-FROM sales GROUP BY product_id;
+-- 2. Table Functions with LIST(...) (for pre-aggregated arrays)
+SELECT * FROM ts_stats('sales', product_id, date, quantity, '1d');
 
 -- 3. Aggregate Functions (for custom GROUP BY)
 SELECT product_id, ts_forecast_agg(date, quantity, 'AutoETS', 12, MAP{}) AS forecast
@@ -68,16 +72,16 @@ FROM sales GROUP BY product_id;
 
 ### Parameter Syntax
 
-Parameters can be passed as MAP (string values) or STRUCT (mixed types):
+Parameters can be passed as MAP (all values quoted as strings) or STRUCT (mixed types):
 
 ```sql
--- STRUCT (recommended)
-SELECT * FROM ts_forecast_by('sales', id, date, val, 'HoltWinters', 12, '1d',
-    MAP{'seasonal_period': '7', 'alpha': '0.2'});
+-- STRUCT (recommended — keeps numeric params typed)
+SELECT * FROM ts_forecast_by('sales', product_id, date, quantity, 'HoltWinters', 12, '1d',
+    {seasonal_period: 7});
 
--- MAP (legacy)
-SELECT * FROM ts_forecast_by('sales', id, date, val, 'HoltWinters', 12, '1d',
-    MAP{'seasonal_period': '7', 'alpha': '0.2'});
+-- MAP (all values must be strings)
+SELECT * FROM ts_forecast_by('sales', product_id, date, quantity, 'HoltWinters', 12, '1d',
+    MAP{'seasonal_period': '7'});
 ```
 
 ## Common Workflows
@@ -85,13 +89,16 @@ SELECT * FROM ts_forecast_by('sales', id, date, val, 'HoltWinters', 12, '1d',
 ### 1. Explore Your Data
 
 ```sql
--- Compute statistics per series
-SELECT * FROM ts_stats('sales', product_id, date, quantity);
+-- Compute statistics per series (table function)
+SELECT * FROM ts_stats('sales', product_id, date, quantity, '1d');
 
--- Check data quality
+-- Check data quality (table function)
+SELECT * FROM ts_data_quality('sales', product_id, date, quantity, 14, '1d');
+
+-- ...or use the aggregate variants with a custom GROUP BY
 SELECT
     product_id,
-    (ts_data_quality(LIST(quantity ORDER BY date))).overall_score AS quality
+    ts_data_quality_agg(date, quantity).overall_score AS quality
 FROM sales
 GROUP BY product_id;
 ```
@@ -99,34 +106,54 @@ GROUP BY product_id;
 ### 2. Detect Seasonality
 
 ```sql
--- Detect seasonal patterns (e.g., weekly = 7, monthly = 30)
+-- Detect seasonal patterns (e.g., weekly = 7, monthly = 30).
+-- Requires the json extension; auto-loaded when SET autoload_known_extensions=1.
 SELECT * FROM ts_detect_periods_by('sales', product_id, date, quantity, MAP{});
 -- Returns: primary_period = 7 (weekly pattern)
 ```
 
-### 3. Evaluate Models
+### 3. Backtest with Cross-Validation
+
+Backtesting uses the two-step CV workflow: split the data into rolling
+train/test folds, then generate a forecast per fold.
 
 ```sql
--- Backtest with detected seasonal period
-SELECT
-    model_name,
-    AVG(abs_error) AS mae,
-    AVG(fold_metric_score) AS rmse
-FROM ts_backtest_auto_by(
+-- Step 1: Create 3 folds with a 7-day test window each
+CREATE OR REPLACE TABLE cv_folds AS
+SELECT * FROM ts_cv_folds_by(
     'sales', product_id, date, quantity,
-    7,       -- 7-day horizon
     3,       -- 3 folds
-    '1d',    -- daily frequency
-    MAP{'method': 'AutoETS', 'seasonal_period': '7'}  -- Use detected period
-)
-GROUP BY model_name;
+    7,       -- 7-day horizon
+    MAP{}
+);
+
+-- Step 2: Fit AutoETS on each fold's train partition and forecast the test partition
+CREATE OR REPLACE TABLE cv_forecasts AS
+SELECT * FROM ts_cv_forecast_by(
+    'cv_folds', product_id, date, quantity,
+    'AutoETS',
+    MAP{'seasonal_period': '7'}   -- Use detected period
+);
+
+-- Step 3: Compute error metrics per series and fold
+SELECT
+    product_id,
+    fold_id,
+    ts_rmse(LIST(y ORDER BY date), LIST(yhat ORDER BY date)) AS rmse,
+    ts_mae(LIST(y ORDER BY date), LIST(yhat ORDER BY date))  AS mae
+FROM cv_forecasts
+GROUP BY product_id, fold_id
+ORDER BY product_id, fold_id;
 ```
+
+See the [Cross-Validation Guide](03-cross-validation.md) for expanding/fixed/sliding
+windows, gap/embargo, and custom cutoffs.
 
 ### 4. Generate Forecasts
 
 ```sql
 -- Production forecasts with seasonal period
-CREATE TABLE forecasts AS
+CREATE OR REPLACE TABLE forecasts AS
 SELECT * FROM ts_forecast_by(
     'sales', product_id, date, quantity,
     'AutoETS', 30, '1d',


### PR DESCRIPTION
## Summary

Fixes three documentation issues reported by @rokf:

- **#224** README ToC — removed the non-existent `Guides` anchor and corrected the emoji-heading anchors (GitHub prefixes them with `-`). Also added the top-level sections that were missing from the ToC (Key Features, Quick Start, Development).
- **#225** Getting Started guide — every SQL snippet was tested against the 1.5.4 build and repaired:
  - `ts_stats` / `ts_data_quality` are **table functions**, not scalars — the guide called them as scalars over `LIST(...)`, which errored out.
  - `ts_backtest_auto_by` no longer exists; replaced with the two-step CV workflow (`ts_cv_folds_by` → `ts_cv_forecast_by`), matching the current `docs/api/08-cross-validation.md`.
  - `ts_detect_periods_by` needs the `json` extension; the install snippet now enables `autoinstall_known_extensions` / `autoload_known_extensions` so it just works.
  - `ts_data_quality` signature is `(source, unique_id_col, date_col, value_col, n_short, frequency)` — the example was missing the last two arguments.
- **#226** Parameter Syntax section — the "STRUCT (recommended)" example accidentally used the same MAP syntax as the "legacy" example (defeating the whole point of the section). Now shows the actual struct literal `{seasonal_period: 7}`; also dropped the invalid `alpha` param, which HoltWinters does not accept.

## Test plan

- [x] Ran every SQL snippet from `docs/guides/01-getting-started.md` end-to-end against `build/release/duckdb + build/release/extension/anofox_forecast/...duckdb_extension` — all pass, no binder / catalog errors.
- [ ] Preview the README on the branch page and click each ToC link.

Closes #224, #225, #226.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786029511&installation_id=142929061&pr_number=230&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F230&signature=ba80ed75b575c90fb1acf4362d1d19328ce891e27320942db88f5b6fedba6e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->