### PR TITLE
deps: bump anofox-forecast crate to 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.5.7"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4985d4fb654424b11ee57c6f308e0359f96d6a082729972d87bf16f3373b5b69"
+checksum = "c603e79764528354bc705153bd8f3cc009dbf8ed54a24d55bf8bd8d7d715f1f7"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",
@@ -57,7 +57,7 @@ dependencies = [
  "faer",
  "getrandom 0.2.16",
  "lbfgs",
- "rand 0.8.5",
+ "rand 0.8.6",
  "statrs",
  "thiserror 2.0.17",
  "trueno",
@@ -97,7 +97,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4248509e270e5fb61677e7a4909ea44c33ec4177c61feb9f438fd36566e834bf"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "statrs",
  "thiserror 2.0.17",
@@ -607,7 +607,7 @@ dependencies = [
  "getrandom 0.2.16",
  "nalgebra",
  "num-complex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr 0.4.3",
  "rayon",
  "rustfft",
@@ -989,7 +989,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr 0.4.3",
  "simba",
  "typenum",
@@ -1114,7 +1114,7 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1323,9 +1323,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1387,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1649,7 +1649,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = "0.5.7"
+anofox-forecast = "0.13.2"
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Bumps the `anofox-forecast` Rust crate from **0.5.7 → 0.13.2**, pulling in
the accumulated forecasting improvements published in the 0.6.x through
0.13.x series (steady-state MLE optimisation, new detrending/seasonal
components, etc.).

## Compatibility notes

- `anofox-forecast 0.13.2` depends on `anofox-regression ^0.5.3`, which
  already matches our workspace pin `=0.5.3` — no downstream bump needed.
- `Cargo.lock` re-locked; the only other change is `rand 0.8.5 → 0.8.6`
  as a transitive artifact.

## Test plan

- [x] `cargo check --workspace` — clean, no API breakage in the FFI or
      core crate.
- [x] `GEN=ninja make release` — full extension build succeeds against
      both DuckDB 1.4.5 LTS and 1.5.4.
- [x] `make test` — all extension tests pass (1274 assertions, 14 test
      cases; 48 skipped tests are the usual `require json` gate that runs
      in CI but not the local dev shell).
- [ ] CI green across Linux/macOS/Windows/Wasm on the matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786089247&installation_id=142929061&pr_number=231&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F231&signature=2c646ccac6f85a755b03fc84fa308548aa18571b845aceefa46c0a5e2ff5b3d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->