### PR TITLE
deps: bump anofox-forecast crate to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c603e79764528354bc705153bd8f3cc009dbf8ed54a24d55bf8bd8d7d715f1f7"
+checksum = "c2d63f01c1296252cae53c55159e5804bb648bab75675b54def1dc2c7838f548"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = "0.13.2"
+anofox-forecast = "0.14.0"
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Bumps the `anofox-forecast` Rust crate from **0.13.2 → 0.14.0** — follow-up to #231.

## Compatibility notes

- `anofox-forecast 0.14.0` still depends on `anofox-regression ^0.5.3`, matching our existing `=0.5.3` workspace pin — no downstream bump needed.
- `Cargo.lock` re-locked; no other transitive changes this round.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `GEN=ninja make release` succeeds (LTS 1.4.5 + latest 1.5.4 dual-track).
- [x] `make test` — 1274 assertions passing (48 `require json` skips are the usual local-shell gate).
- [ ] CI green across the full matrix (Linux / macOS / Windows / Wasm).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786184448&installation_id=142929061&pr_number=232&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F232&signature=88fd648b75611f8475ec67e417d307ed7c8aa2308ab4ec7293a5e12912e26277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->