### PR TITLE
feat: expose LaplaceForecaster as 'Laplace' model with three variants (Wave 1, PR A)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = "0.14.0"
+anofox-forecast = { version = "0.14.0", features = ["anomaly"] }
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates

--- a/crates/anofox-fcst-core/src/forecast.rs
+++ b/crates/anofox-fcst-core/src/forecast.rs
@@ -12,6 +12,7 @@ use anofox_forecast::models::exponential::{
     SeasonalES as SeasonalESModel, SimpleExponentialSmoothing, ETS as ETSModel,
 };
 use anofox_forecast::models::intermittent::{Croston, ADIDA, IMAPA, TSB};
+use anofox_forecast::models::laplace::LaplaceForecaster;
 use anofox_forecast::models::mstl_forecaster::MSTLForecaster;
 use anofox_forecast::models::tbats::{AutoTBATS, TBATS as TBATSModel};
 use anofox_forecast::models::theta::{AutoTheta, DynamicTheta, OptimizedTheta, Theta};
@@ -39,6 +40,51 @@ pub struct ForecastOutput {
     pub bic: Option<f64>,
     /// MSE of in-sample fit
     pub mse: Option<f64>,
+}
+
+/// Selector variant for [`ModelType::Laplace`].
+///
+/// The Laplace forecaster is a streaming distributional shell over
+/// EMA / drift / AR(1) / damped-Holt (and optional seasonal) leaves.
+/// The variant chooses which zero-config selector is used at fit time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LaplaceVariant {
+    /// `LaplaceForecaster::auto()` — balanced defaults for smooth
+    /// economic/continuous series with adequate history.
+    #[default]
+    Auto,
+    /// `LaplaceForecaster::auto_aid()` — AID-based distribution-family
+    /// selection; best for retail SKU / intermittent-demand panels.
+    AutoAid,
+    /// `LaplaceForecaster::skaters()` — the fuller skaters ensemble
+    /// (multi-h scoring, stacking, larger leaf set). Slower, more robust.
+    Skaters,
+}
+
+impl LaplaceVariant {
+    /// Parse a variant name (case-insensitive; `auto`, `auto_aid`, `aid`,
+    /// `skaters`).
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "" | "auto" => Ok(LaplaceVariant::Auto),
+            "auto_aid" | "autoaid" | "aid" => Ok(LaplaceVariant::AutoAid),
+            "skaters" | "skater" => Ok(LaplaceVariant::Skaters),
+            other => Err(ForecastError::InvalidParameter {
+                param: "laplace_variant".to_string(),
+                value: other.to_string(),
+                reason: "expected one of: auto, auto_aid, skaters".to_string(),
+            }),
+        }
+    }
+
+    /// Short tag used inside the returned `model_name` string.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            LaplaceVariant::Auto => "auto",
+            LaplaceVariant::AutoAid => "auto_aid",
+            LaplaceVariant::Skaters => "skaters",
+        }
+    }
 }
 
 /// Available forecast models - matches C++ extension exactly.
@@ -92,6 +138,11 @@ pub enum ModelType {
     ADIDA,
     IMAPA,
     TSB,
+
+    // Distributional Models (1) — Laplace shell over EMA/drift/AR(1)/Holt
+    // leaves. Variant (Auto / AutoAid / Skaters) is carried in
+    // `ForecastOptions.laplace_variant`.
+    Laplace,
 }
 
 impl std::str::FromStr for ModelType {
@@ -140,6 +191,8 @@ impl std::str::FromStr for ModelType {
             "ADIDA" => return Ok(ModelType::ADIDA),
             "IMAPA" => return Ok(ModelType::IMAPA),
             "TSB" => return Ok(ModelType::TSB),
+            // Distributional
+            "Laplace" => return Ok(ModelType::Laplace),
             _ => {}
         }
 
@@ -194,6 +247,8 @@ impl std::str::FromStr for ModelType {
             "adida" => Ok(ModelType::ADIDA),
             "imapa" => Ok(ModelType::IMAPA),
             "tsb" => Ok(ModelType::TSB),
+            // Distributional
+            "laplace" => Ok(ModelType::Laplace),
             // Auto selection (legacy, maps to AutoETS)
             "auto" => Ok(ModelType::AutoETS),
             _ => Err(ForecastError::InvalidModel(format!("Unknown model: {}", s))),
@@ -245,6 +300,8 @@ impl ModelType {
             ModelType::ADIDA => "ADIDA",
             ModelType::IMAPA => "IMAPA",
             ModelType::TSB => "TSB",
+            // Distributional
+            ModelType::Laplace => "Laplace",
         }
     }
 }
@@ -275,6 +332,9 @@ pub struct ForecastOptions {
     pub seasonal_periods: Vec<usize>,
     /// AutoETS model pool (None = Complete/default)
     pub model_pool: Option<String>,
+    /// Laplace forecaster selector (None = Auto). Only consulted when
+    /// [`ModelType::Laplace`] is selected.
+    pub laplace_variant: Option<LaplaceVariant>,
 }
 
 impl Default for ForecastOptions {
@@ -291,6 +351,7 @@ impl Default for ForecastOptions {
             window: 0,
             seasonal_periods: vec![],
             model_pool: None,
+            laplace_variant: None,
         }
     }
 }
@@ -389,6 +450,8 @@ pub struct ForecastOptionsExog {
     pub seasonal_periods: Vec<usize>,
     /// AutoETS model pool (None = Complete/default)
     pub model_pool: Option<String>,
+    /// Laplace forecaster selector (None = Auto).
+    pub laplace_variant: Option<LaplaceVariant>,
 }
 
 impl Default for ForecastOptionsExog {
@@ -406,6 +469,7 @@ impl Default for ForecastOptionsExog {
             window: 0,
             seasonal_periods: vec![],
             model_pool: None,
+            laplace_variant: None,
         }
     }
 }
@@ -425,6 +489,7 @@ impl From<ForecastOptions> for ForecastOptionsExog {
             window: opts.window,
             seasonal_periods: opts.seasonal_periods,
             model_pool: opts.model_pool,
+            laplace_variant: opts.laplace_variant,
         }
     }
 }
@@ -590,6 +655,14 @@ pub fn forecast(values: &[Option<f64>], options: &ForecastOptions) -> Result<For
         ModelType::TSB => forecast_tsb(&clean_values, options.horizon),
         ModelType::ADIDA => forecast_adida(&clean_values, options.horizon),
         ModelType::IMAPA => forecast_imapa(&clean_values, options.horizon),
+        // Distributional
+        ModelType::Laplace => forecast_laplace(
+            &clean_values,
+            options.horizon,
+            period,
+            options.laplace_variant.unwrap_or_default(),
+            options.confidence_level,
+        ),
     }?;
 
     // Calculate confidence intervals
@@ -760,6 +833,8 @@ pub fn forecast_with_exog(
             options.window,
             &options.seasonal_periods,
             options.model_pool.as_deref(),
+            options.laplace_variant.unwrap_or_default(),
+            options.confidence_level,
         )
     }?;
 
@@ -821,6 +896,7 @@ pub fn forecast_with_exog(
 }
 
 /// Internal helper to forecast with a specific model (no exog).
+#[allow(clippy::too_many_arguments)]
 fn forecast_with_model(
     values: &[f64],
     horizon: usize,
@@ -829,6 +905,8 @@ fn forecast_with_model(
     window: usize,
     seasonal_periods: &[usize],
     model_pool: Option<&str>,
+    laplace_variant: LaplaceVariant,
+    confidence_level: f64,
 ) -> Result<ForecastOutput> {
     match model {
         // Basic Models
@@ -914,6 +992,10 @@ fn forecast_with_model(
         ModelType::TSB => forecast_tsb(values, horizon),
         ModelType::ADIDA => forecast_adida(values, horizon),
         ModelType::IMAPA => forecast_imapa(values, horizon),
+        // Distributional
+        ModelType::Laplace => {
+            forecast_laplace(values, horizon, period, laplace_variant, confidence_level)
+        }
     }
 }
 
@@ -1533,6 +1615,82 @@ fn forecast_auto_ets(
             fallback.model_name = "AutoETS".to_string();
             Ok(fallback)
         }
+    }
+}
+
+/// Laplace: streaming distributional shell over EMA / drift / AR(1) / damped-Holt
+/// (and optional seasonal) leaves. Returns a point + interval forecast; the
+/// full mixture parameters are surfaced by the `ts_forecast_dist_by` table
+/// function (PR B of the distributional series).
+fn forecast_laplace(
+    values: &[f64],
+    horizon: usize,
+    period: usize,
+    variant: LaplaceVariant,
+    confidence_level: f64,
+) -> Result<ForecastOutput> {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    let lib_result = catch_unwind(AssertUnwindSafe(|| -> Result<ForecastOutput> {
+        let ts = make_timeseries(values)?;
+
+        let mut model = match variant {
+            LaplaceVariant::Auto => LaplaceForecaster::new().auto(),
+            LaplaceVariant::AutoAid => LaplaceForecaster::new().auto_aid(),
+            LaplaceVariant::Skaters => LaplaceForecaster::new().skaters(),
+        };
+        if period > 1 {
+            model = model.with_seasonal(period);
+        }
+
+        model
+            .fit(&ts)
+            .map_err(|e| ForecastError::ComputationError(format!("Laplace fit failed: {e}")))?;
+
+        // predict_with_intervals uses a symmetric two-sided level; clamp to
+        // [0.5, 0.999] to stay within the LaplaceForecaster's supported range.
+        let level = confidence_level.clamp(0.5, 0.999);
+        let forecast = model.predict_with_intervals(horizon, level).map_err(|e| {
+            ForecastError::ComputationError(format!("Laplace predict failed: {e}"))
+        })?;
+
+        let point = forecast.primary().to_vec();
+        let lower = forecast
+            .lower()
+            .and_then(|intervals| intervals.first())
+            .cloned()
+            .unwrap_or_default();
+        let upper = forecast
+            .upper()
+            .and_then(|intervals| intervals.first())
+            .cloned()
+            .unwrap_or_default();
+
+        let model_name = if period > 1 {
+            format!("Laplace({},seasonal={})", variant.tag(), period)
+        } else {
+            format!("Laplace({})", variant.tag())
+        };
+
+        Ok(ForecastOutput {
+            point,
+            lower,
+            upper,
+            fitted: None,
+            residuals: None,
+            model_name,
+            aic: None,
+            bic: None,
+            mse: None,
+        })
+    }));
+
+    match lib_result {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(ForecastError::ComputationError(
+            "Laplace forecast panicked (likely constant or near-empty series)".to_string(),
+        )),
     }
 }
 
@@ -2206,6 +2364,8 @@ pub fn list_models() -> Vec<String> {
         "ADIDA",
         "IMAPA",
         "TSB",
+        // Distributional Models (1)
+        "Laplace",
     ]
     .into_iter()
     .map(String::from)
@@ -2455,6 +2615,9 @@ mod tests {
             (ModelType::AutoMFLES, &seasonal),
             (ModelType::AutoMSTL, &seasonal),
             (ModelType::AutoTBATS, &seasonal),
+            // Laplace's model_name is `Laplace(<variant>)` or
+            // `Laplace(<variant>,seasonal=<p>)`; must start with "Laplace".
+            (ModelType::Laplace, &seasonal),
         ];
 
         for (model_type, data) in &prefix_cases {
@@ -2489,6 +2652,88 @@ mod tests {
         assert_eq!(result.point.len(), 5);
         assert_eq!(result.model_name, "Theta");
         assert!(result.point.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn test_forecast_laplace_variants() {
+        // Trend + weekly-ish seasonality series that all three Laplace
+        // variants can handle in a smoke test.
+        let values: Vec<Option<f64>> = (0..80)
+            .map(|i| {
+                let trend = i as f64 * 0.1;
+                let seasonal = (i as f64 * std::f64::consts::PI / 7.0).sin() * 2.0;
+                Some(10.0 + trend + seasonal)
+            })
+            .collect();
+
+        for (variant, tag) in [
+            (LaplaceVariant::Auto, "auto"),
+            (LaplaceVariant::AutoAid, "auto_aid"),
+            (LaplaceVariant::Skaters, "skaters"),
+        ] {
+            let options = ForecastOptions {
+                model: ModelType::Laplace,
+                horizon: 6,
+                laplace_variant: Some(variant),
+                ..Default::default()
+            };
+
+            let result = forecast(&values, &options).expect("Laplace forecast should succeed");
+            assert_eq!(result.point.len(), 6, "variant={tag}");
+            assert!(
+                result.point.iter().all(|v| v.is_finite()),
+                "variant={tag} produced non-finite point forecasts"
+            );
+            assert!(
+                result.model_name.starts_with("Laplace("),
+                "variant={tag} model_name={} should start with 'Laplace('",
+                result.model_name
+            );
+            assert!(
+                result.model_name.contains(tag),
+                "variant={tag} model_name={} should contain '{tag}'",
+                result.model_name
+            );
+        }
+    }
+
+    #[test]
+    fn test_forecast_laplace_seasonal_period_in_name() {
+        let values: Vec<Option<f64>> = (0..60)
+            .map(|i| Some(10.0 + (i as f64 * std::f64::consts::PI / 7.0).sin() * 5.0))
+            .collect();
+
+        let options = ForecastOptions {
+            model: ModelType::Laplace,
+            horizon: 5,
+            seasonal_period: 7,
+            auto_detect_seasonality: false,
+            laplace_variant: Some(LaplaceVariant::Auto),
+            ..Default::default()
+        };
+
+        let result = forecast(&values, &options).expect("seasonal Laplace should succeed");
+        assert!(
+            result.model_name.contains("seasonal=7"),
+            "expected seasonal tag in model_name, got '{}'",
+            result.model_name
+        );
+    }
+
+    #[test]
+    fn test_laplace_variant_parse_roundtrip() {
+        assert_eq!(LaplaceVariant::parse("").unwrap(), LaplaceVariant::Auto);
+        assert_eq!(LaplaceVariant::parse("auto").unwrap(), LaplaceVariant::Auto);
+        assert_eq!(
+            LaplaceVariant::parse("Auto_Aid").unwrap(),
+            LaplaceVariant::AutoAid
+        );
+        assert_eq!(LaplaceVariant::parse("AID").unwrap(), LaplaceVariant::AutoAid);
+        assert_eq!(
+            LaplaceVariant::parse("skaters").unwrap(),
+            LaplaceVariant::Skaters
+        );
+        assert!(LaplaceVariant::parse("bogus").is_err());
     }
 
     #[test]

--- a/crates/anofox-fcst-core/src/lib.rs
+++ b/crates/anofox-fcst-core/src/lib.rs
@@ -68,7 +68,7 @@ pub use filter::{
 };
 pub use forecast::{
     forecast, forecast_with_exog, list_models, ExogenousData, ForecastOptions, ForecastOptionsExog,
-    ForecastOutput, ModelType,
+    ForecastOutput, LaplaceVariant, ModelType,
 };
 pub use gaps::{detect_frequency, fill_forward, fill_gaps};
 pub use imputation::{

--- a/crates/anofox-fcst-ffi/src/lib.rs
+++ b/crates/anofox-fcst-ffi/src/lib.rs
@@ -3399,6 +3399,14 @@ pub unsafe extern "C" fn anofox_ts_forecast(
             .filter(|s| !s.is_empty())
             .map(String::from);
 
+        // Parse laplace_variant (empty → default Auto handled downstream)
+        let laplace_variant = CStr::from_ptr(opts.laplace_variant.as_ptr())
+            .to_str()
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(anofox_fcst_core::LaplaceVariant::parse)
+            .transpose()?;
+
         let core_opts = anofox_fcst_core::ForecastOptions {
             model: model_type,
             ets_spec,
@@ -3411,6 +3419,7 @@ pub unsafe extern "C" fn anofox_ts_forecast(
             window: opts.window.max(0) as usize,
             seasonal_periods,
             model_pool,
+            laplace_variant,
         };
 
         anofox_fcst_core::forecast(&series, &core_opts)
@@ -3670,6 +3679,14 @@ pub unsafe extern "C" fn anofox_ts_forecast_exog(
             .filter(|s| !s.is_empty())
             .map(String::from);
 
+        // Parse laplace_variant (empty → default Auto handled downstream)
+        let laplace_variant = CStr::from_ptr(opts.laplace_variant.as_ptr())
+            .to_str()
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(anofox_fcst_core::LaplaceVariant::parse)
+            .transpose()?;
+
         let core_opts = anofox_fcst_core::ForecastOptionsExog {
             model: model_type,
             ets_spec,
@@ -3683,6 +3700,7 @@ pub unsafe extern "C" fn anofox_ts_forecast_exog(
             window: opts.window.max(0) as usize,
             seasonal_periods,
             model_pool,
+            laplace_variant,
         };
 
         anofox_fcst_core::forecast_with_exog(&series, &core_opts)

--- a/crates/anofox-fcst-ffi/src/types.rs
+++ b/crates/anofox-fcst-ffi/src/types.rs
@@ -394,6 +394,9 @@ pub struct ForecastOptions {
     pub seasonal_periods_str: [c_char; 64],
     /// AutoETS model pool (e.g. "reduced", "complete"), empty = default (complete)
     pub model_pool: [c_char; 32],
+    /// Laplace forecaster variant ("auto", "auto_aid", "skaters"), empty = "auto".
+    /// Only consulted when model is "Laplace".
+    pub laplace_variant: [c_char; 16],
 }
 
 impl Default for ForecastOptions {
@@ -415,6 +418,7 @@ impl Default for ForecastOptions {
             window: 0,
             seasonal_periods_str: [0; 64],
             model_pool: [0; 32],
+            laplace_variant: [0; 16],
         }
     }
 }
@@ -481,6 +485,8 @@ pub struct ForecastOptionsExog {
     pub seasonal_periods_str: [c_char; 64],
     /// AutoETS model pool (e.g. "reduced", "complete"), empty = default (complete)
     pub model_pool: [c_char; 32],
+    /// Laplace forecaster variant ("auto", "auto_aid", "skaters"), empty = "auto".
+    pub laplace_variant: [c_char; 16],
 }
 
 impl Default for ForecastOptionsExog {
@@ -503,6 +509,7 @@ impl Default for ForecastOptionsExog {
             window: 0,
             seasonal_periods_str: [0; 64],
             model_pool: [0; 32],
+            laplace_variant: [0; 16],
         }
     }
 }

--- a/src/include/anofox_fcst_ffi.h
+++ b/src/include/anofox_fcst_ffi.h
@@ -1079,6 +1079,11 @@ typedef struct ForecastOptions {
      * AutoETS model pool (e.g. "reduced", "complete"), empty = default (complete)
      */
     char model_pool[32];
+    /**
+     * Laplace forecaster variant ("auto", "auto_aid", "skaters"), empty = "auto".
+     * Only consulted when model is "Laplace".
+     */
+    char laplace_variant[16];
 } ForecastOptions;
 
 /**
@@ -1225,6 +1230,10 @@ typedef struct ForecastOptionsExog {
      * AutoETS model pool (e.g. "reduced", "complete"), empty = default (complete)
      */
     char model_pool[32];
+    /**
+     * Laplace forecaster variant ("auto", "auto_aid", "skaters"), empty = "auto".
+     */
+    char laplace_variant[16];
 } ForecastOptionsExog;
 
 /**

--- a/src/scalar_functions/ts_forecast_scalar.cpp
+++ b/src/scalar_functions/ts_forecast_scalar.cpp
@@ -46,6 +46,7 @@ struct TsForecastScalarBindData : public FunctionData {
     int64_t window = 0;
     string seasonal_periods_str = "";
     string model_pool = "";
+    string laplace_variant = "";
 
     DateColumnType date_col_type = DateColumnType::DATE;
 
@@ -62,6 +63,7 @@ struct TsForecastScalarBindData : public FunctionData {
         copy->window = window;
         copy->seasonal_periods_str = seasonal_periods_str;
         copy->model_pool = model_pool;
+        copy->laplace_variant = laplace_variant;
         copy->date_col_type = date_col_type;
         return std::move(copy);
     }
@@ -87,6 +89,17 @@ static string ParseStringParam(const Value &params_value, const string &key, con
             auto &v = StructValue::GetChildren(child)[1];
             if (k.ToString() == key && !v.IsNull()) return v.ToString();
         }
+    } else if (params_value.type().id() == LogicalTypeId::STRUCT) {
+        // Mirrors ts_forecast_native.cpp — accept typed STRUCT params too,
+        // so `{seasonal_period: 7, laplace_variant: 'auto'}` behaves the same
+        // as the equivalent MAP.
+        auto &struct_children = StructValue::GetChildren(params_value);
+        auto &child_types = StructType::GetChildTypes(params_value.type());
+        for (idx_t i = 0; i < child_types.size(); i++) {
+            if (child_types[i].first == key && !struct_children[i].IsNull()) {
+                return struct_children[i].ToString();
+            }
+        }
     }
     return default_val;
 }
@@ -105,7 +118,8 @@ static double ParseDoubleParam(const Value &params_value, const string &key, dou
 
 static void ValidateParams(const Value &params_value, const string &method) {
     static const unordered_set<string> valid_keys = {
-        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool"
+        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool",
+        "laplace_variant"
     };
 
     if (params_value.IsNull()) return;
@@ -120,6 +134,13 @@ static void ValidateParams(const Value &params_value, const string &method) {
                 unknown_keys.push_back(key_str);
             }
         }
+    } else if (params_value.type().id() == LogicalTypeId::STRUCT) {
+        auto &child_types = StructType::GetChildTypes(params_value.type());
+        for (idx_t i = 0; i < child_types.size(); i++) {
+            if (valid_keys.find(child_types[i].first) == valid_keys.end()) {
+                unknown_keys.push_back(child_types[i].first);
+            }
+        }
     }
 
     if (!unknown_keys.empty()) {
@@ -129,7 +150,7 @@ static void ValidateParams(const Value &params_value, const string &method) {
             unknown_list += "'" + unknown_keys[i] + "'";
         }
         throw InvalidInputException(
-            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool",
+            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool, laplace_variant",
             unknown_list);
     }
 }
@@ -394,6 +415,7 @@ static void TsForecastScalarExecute(DataChunk &args, ExpressionState &state, Vec
         string model_spec = bind_data.model_spec;
         string seasonal_periods_str = bind_data.seasonal_periods_str;
         string model_pool = bind_data.model_pool;
+        string laplace_variant = bind_data.laplace_variant;
 
         auto p_idx = params_data.sel->get_index(row_idx);
         if (params_data.validity.RowIsValid(p_idx)) {
@@ -405,6 +427,7 @@ static void TsForecastScalarExecute(DataChunk &args, ExpressionState &state, Vec
             window_param = ParseInt64Param(params_val, "window", 0);
             seasonal_periods_str = ParseStringParam(params_val, "seasonal_periods", "");
             model_pool = ParseStringParam(params_val, "model_pool", "");
+            laplace_variant = ParseStringParam(params_val, "laplace_variant", "");
         }
 
         // --- Build ForecastOptions ---
@@ -431,6 +454,11 @@ static void TsForecastScalarExecute(DataChunk &args, ExpressionState &state, Vec
         if (!model_pool.empty()) {
             strncpy(opts.model_pool, model_pool.c_str(), sizeof(opts.model_pool) - 1);
             opts.model_pool[sizeof(opts.model_pool) - 1] = '\0';
+        }
+        if (!laplace_variant.empty()) {
+            strncpy(opts.laplace_variant, laplace_variant.c_str(),
+                    sizeof(opts.laplace_variant) - 1);
+            opts.laplace_variant[sizeof(opts.laplace_variant) - 1] = '\0';
         }
 
         // --- Call Rust FFI ---

--- a/src/table_functions/ts_cv_forecast_native.cpp
+++ b/src/table_functions/ts_cv_forecast_native.cpp
@@ -45,6 +45,7 @@ struct TsCvForecastNativeBindData : public TableFunctionData {
     int64_t window = 0;
     string seasonal_periods_str = "";
     string model_pool = "";
+    string laplace_variant = "";
 
     // Column indices (resolved by name in bind)
     idx_t fold_id_col = 0;
@@ -250,7 +251,8 @@ static string MakeCompositeKey(int64_t fold_id, const string &group_key) {
 
 static void ValidateParamKeys(const Value &params_value) {
     static const unordered_set<string> valid_keys = {
-        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool"
+        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool",
+        "laplace_variant"
     };
 
     vector<string> unknown_keys;
@@ -280,7 +282,7 @@ static void ValidateParamKeys(const Value &params_value) {
             unknown_list += "'" + unknown_keys[i] + "'";
         }
         throw InvalidInputException(
-            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool",
+            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool, laplace_variant",
             unknown_list);
     }
 }
@@ -380,6 +382,7 @@ static unique_ptr<FunctionData> TsCvForecastNativeBind(
         bind_data->window = ParseInt64FromParams(params, "window", 0);
         bind_data->seasonal_periods_str = ParseStringFromParams(params, "seasonal_periods", "");
         bind_data->model_pool = ParseStringFromParams(params, "model_pool", "");
+        bind_data->laplace_variant = ParseStringFromParams(params, "laplace_variant", "");
 
         // Validate confidence_level range
         if (bind_data->confidence_level <= 0.0 || bind_data->confidence_level >= 1.0) {
@@ -686,6 +689,11 @@ static OperatorFinalizeResultType TsCvForecastNativeFinalize(
                 strncpy(opts.model_pool, bind_data.model_pool.c_str(),
                         sizeof(opts.model_pool) - 1);
                 opts.model_pool[sizeof(opts.model_pool) - 1] = '\0';
+            }
+            if (!bind_data.laplace_variant.empty()) {
+                strncpy(opts.laplace_variant, bind_data.laplace_variant.c_str(),
+                        sizeof(opts.laplace_variant) - 1);
+                opts.laplace_variant[sizeof(opts.laplace_variant) - 1] = '\0';
             }
 
             // Call Rust FFI

--- a/src/table_functions/ts_forecast_native.cpp
+++ b/src/table_functions/ts_forecast_native.cpp
@@ -45,6 +45,7 @@ struct TsForecastNativeBindData : public TableFunctionData {
     int64_t window = 0;
     string seasonal_periods_str = "";
     string model_pool = "";
+    string laplace_variant = "";
 
     // Type preservation
     DateColumnType date_col_type = DateColumnType::TIMESTAMP;
@@ -267,7 +268,8 @@ static double ParseDoubleFromParams(const Value &params_value, const string &key
 
 static void ValidateParamKeys(const Value &params_value) {
     static const unordered_set<string> valid_keys = {
-        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool"
+        "model", "seasonal_period", "seasonal_periods", "confidence_level", "window", "model_pool",
+        "laplace_variant"
     };
 
     vector<string> unknown_keys;
@@ -297,7 +299,7 @@ static void ValidateParamKeys(const Value &params_value) {
             unknown_list += "'" + unknown_keys[i] + "'";
         }
         throw InvalidInputException(
-            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool",
+            "Unknown parameter(s): %s. Valid parameters are: model, seasonal_period, seasonal_periods, confidence_level, window, model_pool, laplace_variant",
             unknown_list);
     }
 }
@@ -346,6 +348,7 @@ static unique_ptr<FunctionData> TsForecastNativeBind(
         bind_data->window = ParseInt64FromParams(params, "window", 0);
         bind_data->seasonal_periods_str = ParseStringFromParams(params, "seasonal_periods", "");
         bind_data->model_pool = ParseStringFromParams(params, "model_pool", "");
+        bind_data->laplace_variant = ParseStringFromParams(params, "laplace_variant", "");
 
         // Validate confidence_level range
         if (bind_data->confidence_level <= 0.0 || bind_data->confidence_level >= 1.0) {
@@ -635,6 +638,11 @@ static OperatorFinalizeResultType TsForecastNativeFinalize(
                 strncpy(opts.model_pool, bind_data.model_pool.c_str(),
                         sizeof(opts.model_pool) - 1);
                 opts.model_pool[sizeof(opts.model_pool) - 1] = '\0';
+            }
+            if (!bind_data.laplace_variant.empty()) {
+                strncpy(opts.laplace_variant, bind_data.laplace_variant.c_str(),
+                        sizeof(opts.laplace_variant) - 1);
+                opts.laplace_variant[sizeof(opts.laplace_variant) - 1] = '\0';
             }
 
             // Call Rust FFI

--- a/test/sql/ts_forecast_laplace.test
+++ b/test/sql/ts_forecast_laplace.test
@@ -1,0 +1,123 @@
+# name: test/sql/ts_forecast_laplace.test
+# description: Smoke tests for the Laplace distributional forecaster (three variants + seasonal + intermittent).
+# group: [sql]
+
+require anofox_forecast
+
+require json
+
+#######################################
+# Setup
+#######################################
+
+# Trend + weekly seasonality (80 points — enough warmup for auto/skaters)
+statement ok
+CREATE TABLE laplace_seasonal AS
+SELECT
+    'A' AS id,
+    ('2024-01-01'::DATE + (i || ' day')::INTERVAL)::TIMESTAMP AS ds,
+    10.0 + i * 0.1 + sin(i * pi() / 7.0) * 3.0 AS y
+FROM generate_series(0, 79) AS t(i);
+
+# Intermittent-demand series (mostly zeros, occasional counts) for auto_aid
+statement ok
+CREATE TABLE laplace_intermittent AS
+SELECT
+    'B' AS id,
+    ('2024-01-01'::DATE + (i || ' day')::INTERVAL)::TIMESTAMP AS ds,
+    CASE
+        WHEN i % 5 = 0 THEN 3.0
+        WHEN i % 11 = 0 THEN 2.0
+        ELSE 0.0
+    END AS y
+FROM generate_series(0, 99) AS t(i);
+
+#######################################
+# Variant: auto (default when laplace_variant not set)
+#######################################
+
+query I
+SELECT COUNT(*) FROM ts_forecast_by(
+    'laplace_seasonal', id, ds, y, 'Laplace', 7, '1d', MAP{'seasonal_period': '7'}
+);
+----
+7
+
+# Auto variant produces finite point + interval forecasts
+query I
+SELECT bool_and(yhat IS NOT NULL AND yhat_lower IS NOT NULL AND yhat_upper IS NOT NULL
+                AND yhat_lower <= yhat AND yhat <= yhat_upper)
+FROM ts_forecast_by('laplace_seasonal', id, ds, y, 'Laplace', 7, '1d', MAP{'seasonal_period': '7'});
+----
+true
+
+# model_name for auto includes the variant tag
+query I
+SELECT model_name LIKE 'Laplace(auto%'
+FROM ts_forecast_by('laplace_seasonal', id, ds, y, 'Laplace', 5, '1d', MAP{'seasonal_period': '7'})
+LIMIT 1;
+----
+true
+
+# seasonal_period appears in model_name
+query I
+SELECT model_name LIKE '%seasonal=7%'
+FROM ts_forecast_by('laplace_seasonal', id, ds, y, 'Laplace', 5, '1d', MAP{'seasonal_period': '7'})
+LIMIT 1;
+----
+true
+
+#######################################
+# Variant: auto_aid (intermittent-friendly selector)
+#######################################
+
+query I
+SELECT model_name LIKE 'Laplace(auto_aid%'
+FROM ts_forecast_by('laplace_intermittent', id, ds, y, 'Laplace', 7, '1d',
+    MAP{'laplace_variant': 'auto_aid'})
+LIMIT 1;
+----
+true
+
+# auto_aid returns non-negative point forecasts on non-negative intermittent series
+query I
+SELECT bool_and(yhat IS NOT NULL AND yhat >= 0.0)
+FROM ts_forecast_by('laplace_intermittent', id, ds, y, 'Laplace', 7, '1d',
+    MAP{'laplace_variant': 'auto_aid'});
+----
+true
+
+#######################################
+# Variant: skaters (full ensemble)
+#######################################
+
+query I
+SELECT model_name LIKE 'Laplace(skaters%'
+FROM ts_forecast_by('laplace_seasonal', id, ds, y, 'Laplace', 5, '1d',
+    MAP{'laplace_variant': 'skaters', 'seasonal_period': '7'})
+LIMIT 1;
+----
+true
+
+#######################################
+# STRUCT params (typed keys — the recommended surface)
+#######################################
+
+query I
+SELECT COUNT(*) FROM ts_forecast_by(
+    'laplace_seasonal', id, ds, y, 'Laplace', 5, '1d',
+    {laplace_variant: 'auto_aid', seasonal_period: 7}
+);
+----
+5
+
+#######################################
+# Error path: unknown variant string
+#######################################
+
+statement error
+SELECT * FROM ts_forecast_by(
+    'laplace_seasonal', id, ds, y, 'Laplace', 5, '1d',
+    MAP{'laplace_variant': 'bogus_variant'}
+);
+----


### PR DESCRIPTION
## Summary

First of three PRs (A / B / C) exposing the streaming distributional Laplace forecaster and, later, the Mahalanobis anomaly detector. This PR ships **PR A**: the point-forecast surface for `LaplaceForecaster`.

- New model string `'Laplace'` accepted by `ts_forecast_by` / `ts_forecast_agg` / `_ts_forecast_scalar` and `ts_cv_forecast_by`.
- New param `laplace_variant` selects one of the three zero-config selectors: `'auto'` (default), `'auto_aid'` (retail/intermittent), `'skaters'` (full ensemble).
- The returned `model_name` tags the variant + seasonal period: `Laplace(auto_aid,seasonal=7)`.
- Point forecasts + prediction intervals (`yhat` / `yhat_lower` / `yhat_upper`) come out of `LaplaceForecaster::predict_with_intervals`. Per-horizon `GaussianMixture` parameters are deferred to **PR B** (`ts_forecast_dist_by`).

## Base

Based on `bump-anofox-forecast-0.14.0` (#232). Rebase to `main` once #232 merges.

## Wave 0 — crate feature flip

`Cargo.toml`: `anofox-forecast = { version = "0.14.0", features = ["anomaly"] }`. Transitively enables `distributional`, which is what `LaplaceForecaster` sits behind. Also compiles in the `MahalanobisDetector` used by **PR C**.

## Sidebar fix (STRUCT params in the scalar path)

While adding the `laplace_variant` param, I noticed that `_ts_forecast_scalar`'s `ParseStringParam` / `ValidateParams` only accepted MAP-typed params. STRUCT-syntax params like `{seasonal_period: 7}` — which the getting-started guide now recommends — silently defaulted through this path. Both helpers now handle STRUCT the same way the native table function already did.

## Test plan

- [x] `cargo test -p anofox-fcst-core` — 3 new unit tests for `LaplaceVariant::parse`, three-variant smoke, and seasonal-in-name; existing `test_all_model_names_match_enum` regression extended to include `ModelType::Laplace`.
- [x] `GEN=ninja make release` — clean.
- [x] `make test` — all 1274 assertions pass; new `test/sql/ts_forecast_laplace.test` covers auto / auto_aid / skaters, MAP + STRUCT param surfaces, and the invalid-variant error path.
- [x] Manual end-to-end via the release CLI: three variants produce distinct `model_name`s and non-negative `yhat` on intermittent data.
- [ ] CI green across Linux / macOS / Windows / Wasm.

## Next up

- **PR B** — `ts_forecast_dist_by` returning per-horizon mixture params.
- **PR C** — `ts_anomaly_by` composing on `LaplaceForecaster + MahalanobisDetector` for streaming Mahalanobis anomaly detection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786186149&installation_id=142929061&pr_number=233&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F233&signature=3b2d0aafaa1be66374ac181d158a13cff708e164c81c6ce0b4362b7003bc9765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->