### PR TITLE
deps: bump anofox-forecast crate to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.13.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c603e79764528354bc705153bd8f3cc009dbf8ed54a24d55bf8bd8d7d715f1f7"
+checksum = "243af6a8cd21ac8c6654cd2f8e984b73ff51f9205be999d67bd14b4ada61218b"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = "0.13.2"
+anofox-forecast = "0.15.1"
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Bumps the `anofox-forecast` Rust crate from **0.13.2 → 0.15.1** (supersedes the closed #234 which targeted 0.15.0).

## What's in 0.15.1

Direct fix for the amplitude-decline pathology tracked at [sipemu/anofox-forecast#195](https://github.com/sipemu/anofox-forecast/issues/195):

- `LaplaceForecaster::auto_with_seasonal_period()` now actually adds a `SeasonalEmaLeaf` to the leaf pool. Previously it only set the ACF fallback used by `.auto()` — so `.skaters().auto_with_seasonal_period(12)` didn't put a seasonal-EMA leaf in the pool, level-tracker leaves dominated, and the forecast collapsed to a near-flat line on amplitude-declining series.
- `with_seasonal_batch_init()` gained clearer trade-off docstrings (safe on stationary / declining amplitude, avoid on growing amplitude or phase-shifted seasonality).

Our extension uses `.with_seasonal(period)` which was already correct, so no wiring change is needed just to pick up the fix. PR #235 (stacked on this branch) additionally exposes the `with_seasonal_batch_init()` opt-in as a user-facing `laplace_seasonal_batch_init` param.

## Compatibility notes

- 0.15.1 still depends on `anofox-regression ^0.5.3`, matching our existing `=0.5.3` workspace pin — no downstream bump needed.
- `Cargo.lock` re-locked; no other transitive changes.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `GEN=ninja make release` succeeds (LTS 1.4.5 + latest 1.5.4 dual-track).
- [x] `make test` — 1274 assertions passing (48 `require json` skips are the usual local-shell gate).
- [ ] CI green across Linux / macOS / Windows / Wasm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786215663&installation_id=142929061&pr_number=237&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F237&signature=022a74c9d0706505cf6bdff1a250e5258a611bec97051d848949cafd5ea6aecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->