### PR TITLE
fix: link Rust FFI archive into WASM build (#239)

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,4 +3,16 @@
 duckdb_extension_load(anofox_forecast
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    # On WASM builds the extension target is a STATIC library and the final
+    # link happens in a post-build emcc step (extension_build_tools.cmake:196)
+    # that reads its extra archives from DUCKDB_EXTENSION_ANOFOX_FORECAST_LINKED_LIBS.
+    # Without this, the Rust FFI static archive (target: anofox_fcst_ffi, defined
+    # in CMakeLists.txt via corrosion_import_crate) is never linked into the .wasm,
+    # so all 84 anofox_ts_* / anofox_free_* FFI symbols end up as unresolvable
+    # imports and LOAD fails with "TypeError: r is not a function" (issue #239).
+    # Corrosion creates two targets: `anofox_fcst_ffi` (INTERFACE — for
+    # `target_link_libraries`) and `anofox_fcst_ffi-static` (the actual STATIC
+    # IMPORTED archive). We need the -static suffix here so TARGET_FILE
+    # resolves to the .a file path.
+    LINKED_LIBS "$<TARGET_FILE:anofox_fcst_ffi-static>"
 )


### PR DESCRIPTION
Closes #239.

## Summary

The WASM build was missing the entire Rust FFI surface — 84 unresolved `anofox_ts_*` / `anofox_free_*` imports — causing `LOAD anofox_forecast` to throw \`TypeError: r is not a function\` at first use in DuckDB-Wasm.

## Root cause

On EMSCRIPTEN, DuckDB's extension build system creates the extension target as a **STATIC** library and defers the final link to a post-build \`emcc -sSIDE_MODULE=2\` step (\`extension_build_tools.cmake:196\`):

\`\`\`cmake
COMMAND emcc \$<TARGET_FILE:\${TARGET_NAME}> -o \${...}.wasm -O3 -sSIDE_MODULE=2 \\
    -sEXPORTED_FUNCTIONS=\"\${EXPORTED_FUNCTIONS}\" \${WASM_THREAD_FLAGS} \${TO_BE_LINKED}
\`\`\`

\`\${TO_BE_LINKED}\` reads from \`DUCKDB_EXTENSION_ANOFOX_FORECAST_LINKED_LIBS\`, populated by \`LINKED_LIBS\` on \`duckdb_extension_load()\`. We never passed it.

On Linux/macOS/Windows this doesn't manifest because the extension is built as a **SHARED** library and \`target_link_libraries(_extension \${RUST_LIB})\` in \`CMakeLists.txt\` pulls in \`libanofox_fcst_ffi.a\` at the shared-library link step. On WASM, \`target_link_libraries\` on a STATIC target only records an interface dependency — the emcc post-build never sees the Rust archive.

## Fix

One line in \`extension_config.cmake\` — pass the corrosion \`-static\` variant of the Rust archive as \`LINKED_LIBS\`:

\`\`\`diff
 duckdb_extension_load(anofox_forecast
     SOURCE_DIR \${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    LINKED_LIBS \"\$<TARGET_FILE:anofox_fcst_ffi-static>\"
 )
\`\`\`

Corrosion creates two targets: \`anofox_fcst_ffi\` (INTERFACE — for \`target_link_libraries\`) and \`anofox_fcst_ffi-static\` (the actual STATIC IMPORTED archive). The \`-static\` suffix is needed so \`\$<TARGET_FILE:...>\` resolves to the \`.a\` file path.

## Verification

Local WASM build (emsdk 3.1.71 + \`wasm32-unknown-emscripten\` Rust target), with and without the fix:

| Property | Before (broken CI) | After (this PR) |
|---|---|---|
| \`.wasm\` size | 1.77 MB | 3.92 MB |
| Unresolved \`anofox_ts_*\` / \`anofox_free_*\` FFI imports | **84** | **0** |
| Rust code embedded (mstl_forecaster / Theta / TSB / ADIDA / IMAPA \`Forecaster::fit,predict\` trait impls) | absent | present |
| Rust \`src/models/*\` panic strings in binary | 0 | 20+ |

Full pre/post import + export dumps captured in the investigation scratchpad; happy to attach if useful.

## Non-WASM impact

\`LINKED_LIBS\` is only consumed inside the \`if(EMSCRIPTEN)\` branch of \`build_loadable_extension_directory\` (\`extension_build_tools.cmake:183-198\`). On Linux/macOS/Windows the variable is set but never read — no behavioural change to native builds.

## Test plan

- [x] \`make wasm_eh\` locally — emits a 3.9 MB \`.wasm\` with 0 unresolved FFI imports (verified via WASM import section dump).
- [ ] CI green across the wasm_mvp / wasm_eh / wasm_threads matrix.
- [ ] End-to-end LOAD test in DuckDB-Wasm browser once CI publishes the artifact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786222569&installation_id=142929061&pr_number=240&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F240&signature=9c224e1b88a168a053d45f44b91ac76ba72c21ec8d8b61637ce5e45c4a5108fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->