### PR TITLE
deps: bump anofox-forecast crate to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243af6a8cd21ac8c6654cd2f8e984b73ff51f9205be999d67bd14b4ada61218b"
+checksum = "09238c04665aa3aa8d191c4e47eb9f47662816db4fa05bef785eef1defa6eb96"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = { version = "0.15.1", features = ["anomaly"] }
+anofox-forecast = { version = "0.15.2", features = ["anomaly"] }
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Bumps the \`anofox-forecast\` Rust crate from **0.15.1 → 0.15.2**.

## What's in 0.15.2

Single new public method: \`LaplaceForecaster::no_seasonal_batch_init()\` — the symmetric off-toggle counterpart to \`with_seasonal_batch_init()\`. Useful for callers building the forecaster via a builder chain and needing to un-set the flag conditionally. Our default state already matches (\`batch_init = false\`), so no code change in the extension.

## Compatibility notes

- Still depends on \`anofox-regression ^0.5.3\`, matching our existing \`=0.5.3\` workspace pin — no downstream bump needed.
- \`Cargo.lock\` re-locked; no other transitive changes.

## Test plan

- [x] \`cargo check --workspace\` clean.
- [x] \`GEN=ninja make release\` succeeds (LTS 1.4.5 + latest 1.5.4 dual-track).
- [x] \`make test\` — 1274 assertions passing (48 \`require json\` skips are the usual local-shell gate).
- [ ] CI green across Linux / macOS / Windows / Wasm.

## Note for #241 (Laplace surface PR)

#241 is currently based on \`main\` (which has 0.15.1). Once this bump merges, #241 will auto-retarget \`main\` and inherit 0.15.2 — no rewiring needed since none of the Laplace params depend on the new symmetric toggle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226712&installation_id=142929061&pr_number=242&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F242&signature=eebacb49afbf4b5b29ec10c1d78ceaaa2e297e8328105013b4437a4a44aceaab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->