### PR TITLE
ci: add erpl.io deploy pipeline (mirrors anofox-statistics)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# OIDC token needed for AWS credentials in the deploy job.
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
@@ -24,6 +29,23 @@ jobs:
       # windows_amd64_mingw: rtools42 MinGW lacks libbcrypt.a needed by Rust getrandom 0.3+
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'
 
+  duckdb-lts-deploy:
+    name: Deploy extension binaries (v1.4.5 LTS)
+    needs: duckdb-lts-build
+    # Run the deploy step even when a non-essential build matrix entry fails.
+    # The deploy job itself fans out per arch and only pushes the artifacts
+    # that actually exist.
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_extension_deploy.yml
+    secrets: inherit
+    with:
+      duckdb_version: v1.4.5
+      ci_tools_version: v1.4-andium
+      extension_name: anofox_forecast
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+
   duckdb-latest-build:
     name: Build extension binaries (DuckDB latest v1.5.4)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
@@ -35,6 +57,20 @@ jobs:
       # windows_amd64_rtools: only needed for R package builds
       # windows_amd64_mingw: rtools42 MinGW lacks libbcrypt.a needed by Rust getrandom 0.3+
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'
+
+  duckdb-latest-deploy:
+    name: Deploy extension binaries (v1.5.4)
+    needs: duckdb-latest-build
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/_extension_deploy.yml
+    secrets: inherit
+    with:
+      duckdb_version: v1.5.4
+      ci_tools_version: v1.5-variegata
+      extension_name: anofox_forecast
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
   build-and-test-rust:
     name: Rust Tests

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -1,36 +1,56 @@
 #
-# Reusable workflow that deploys the artifacts produced by the extension distribution pipeline
+# Reusable workflow that deploys the artifacts produced by github.com/duckdb/duckdb/.github/workflows/_extension_distribution.yml
 #
+# note: this workflow needs to be located in the extension repository, as it requires secrets to be passed to the
+# deploy script. However, it should generally not be necessary to modify this workflow in your extension repository, as
+# this workflow can be configured to use a custom deploy script.
+
+
 name: Extension Deployment
 on:
   workflow_call:
     inputs:
+      # The name of the extension
       extension_name:
         required: true
         type: string
+      # DuckDB version to build against
       duckdb_version:
         required: true
         type: string
+      # The extension-ci-tools ref (branch/tag) matching duckdb_version. Required
+      # because the rolling patch releases (e.g. v1.5.4 / v1.4.5) have no matching
+      # extension-ci-tools branch — the codename branches (v1.5-variegata /
+      # v1.4-andium) are the canonical targets instead.
+      ci_tools_version:
+        required: true
+        type: string
+      # ';' separated list of architectures to exclude, for example: 'linux_amd64;osx_arm64'
       exclude_archs:
         required: false
         type: string
         default: ""
+      # Whether to upload this deployment as the latest. This may overwrite a previous deployment.
       deploy_latest:
         required: false
         type: boolean
         default: false
+      # Whether to upload this deployment under a versioned path. These will not be deleted automatically
       deploy_versioned:
         required: false
         type: boolean
         default: false
+      # Postfix added to artifact names. Can be used to guarantee unique names when this workflow is called multiple times
       artifact_postfix:
         required: false
         type: string
         default: ""
+      # Override the default deploy script with a custom script
       deploy_script:
         required: false
         type: string
         default: "./scripts/extension-upload.sh"
+      # Override the default matrix parse script with a custom script
       matrix_parse_script:
         required: false
         type: string
@@ -43,7 +63,7 @@ jobs:
     outputs:
       deploy_matrix: ${{ steps.parse-matrices.outputs.deploy_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: 'true'
@@ -51,13 +71,26 @@ jobs:
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
+          git fetch --depth 1 origin tag ${{ inputs.duckdb_version }}
           git checkout ${{ inputs.duckdb_version }}
+
+      - name: Checkout extension-ci-tools to version
+        # Submodules are pinned to the stable DuckDB version; for the
+        # LTS deploy we need the matching tools so the parsed
+        # architecture matrix lines up with what the LTS build job
+        # produced. Branch first, tag fallback.
+        run: |
+          cd extension-ci-tools
+          git fetch --depth 1 origin ${{ inputs.ci_tools_version }} || \
+            git fetch --depth 1 origin tag ${{ inputs.ci_tools_version }}
+          git checkout FETCH_HEAD
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input ./extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input ./extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --reduced_ci_mode auto --pretty
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
+          echo `cat $GITHUB_OUTPUT`
 
   deploy:
     name: Deploy
@@ -65,6 +98,10 @@ jobs:
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.deploy_matrix != '{}' && needs.generate_matrix.outputs.deploy_matrix != '' }}
     strategy:
+      # One missing artifact (e.g. a Windows build that didn't produce one)
+      # must not cancel sibling per-arch deploys — Linux / macOS / wasm
+      # publishing should proceed independently.
+      fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
 
     steps:
@@ -73,9 +110,17 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::331993160594:role/ErplGithubOicdRole
+          role-session-name: ErplGithubOicdSession
+          aws-region: eu-west-1
+
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
+          git fetch --depth 1 origin tag ${{ inputs.duckdb_version }}
           git checkout ${{ inputs.duckdb_version }}
 
       - uses: actions/download-artifact@v4
@@ -89,6 +134,7 @@ jobs:
         env:
           BUCKET_NAME: ${{ vars.DEPLOY_S3_BUCKET }}
         run: |
+          pwd
           python3 -m pip install pip awscli
           git config --global --add safe.directory '*'
           cd duckdb

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Extension upload script
+
+# Usage: ./extension-upload.sh <name> <extension_version> <duckdb_version> <architecture> <s3_bucket> <copy_to_latest> <copy_to_versioned>
+# <name>                : Name of the extension
+# <extension_version>   : Version (commit / version tag) of the extension
+# <duckdb_version>      : Version (commit / version tag) of DuckDB
+# <architecture>        : Architecture target of the extension binary
+# <s3_bucket>           : S3 bucket to upload to
+# <copy_to_latest>      : Set this as the latest version ("true" / "false", default: "false")
+# <copy_to_versioned>   : Set this as a versioned version that will prevent its deletion
+
+set -e
+
+if [[ $4 == wasm* ]]; then
+  ext="/tmp/extension/$1.duckdb_extension.wasm"
+else
+  ext="/tmp/extension/$1.duckdb_extension"
+fi
+
+echo $ext
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+# The build artifact already ends with a 256-byte signature placeholder
+# (zero-filled when unsigned). Strip it before computing the hash and
+# re-appending a fresh signature — otherwise we'd end up with 512 bytes
+# of trailing data and the metadata footer would no longer be at the
+# fixed offset DuckDB v1.5.3+ checks, causing the install to fail with
+# "metadata at the end of the file is invalid".
+#
+# wasm artifacts do not carry the placeholder, so the strip is gated on
+# the native-binary path only.
+cat $ext > $ext.append
+if [[ $4 != wasm* ]]; then
+  truncate -s -256 $ext.append
+fi
+
+if [[ $4 == wasm* ]]; then
+  # 0 for custom section
+  # 113 in hex = 275 in decimal, total lenght of what follows (1 + 16 + 2 + 256)
+  # [1(continuation) + 0010011(payload) = \x93, 0(continuation) + 10(payload) = \x02]
+  echo -n -e '\x00' >> $ext.append
+  echo -n -e '\x93\x02' >> $ext.append
+  # 10 in hex = 16 in decimal, lenght of name, 1 byte
+  echo -n -e '\x10' >> $ext.append
+  echo -n -e 'duckdb_signature' >> $ext.append
+  # the name of the WebAssembly custom section, 16 bytes
+  # 100 in hex, 256 in decimal
+  # [1(continuation) + 0000000(payload) = ff, 0(continuation) + 10(payload)],
+  # for a grand total of 2 bytes
+  echo -n -e '\x80\x02' >> $ext.append
+fi
+
+# (Optionally) Sign binary
+if [ "$DUCKDB_EXTENSION_SIGNING_PK" != "" ]; then
+  echo "$DUCKDB_EXTENSION_SIGNING_PK" > private.pem
+  $script_dir/../duckdb/scripts/compute-extension-hash.sh $ext.append > $ext.hash
+  openssl pkeyutl -sign -in $ext.hash -inkey private.pem -pkeyopt digest:sha256 -out $ext.sign
+  rm -f private.pem
+fi
+
+# Signature is always there, potentially defaulting to 256 zeros
+truncate -s 256 $ext.sign
+
+# append signature to extension binary
+cat $ext.sign >> $ext.append
+
+# compress extension binary
+if [[ $4 == wasm_* ]]; then
+  brotli < $ext.append > "$ext.compressed"
+else
+  gzip < $ext.append > "$ext.compressed"
+fi
+
+set -e
+
+# Abort if AWS key is not set
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "No AWS key found, skipping.."
+    exit 0
+fi
+
+# upload versioned version
+if [[ $7 = 'true' ]]; then
+  if [[ $4 == wasm* ]]; then
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+  else
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz --acl public-read
+  fi
+fi
+
+# upload to latest version
+if [[ $6 = 'true' ]]; then
+  if [[ $4 == wasm* ]]; then
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+  else
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.gz --acl public-read
+  fi
+fi


### PR DESCRIPTION
Mirrors the erpl.io extension-distribution setup already in production on the sister extension [DataZooDE/anofox-statistics](https://github.com/DataZooDE/anofox-statistics). After this lands, users can

\`\`\`sql
SET custom_extension_repository = 'https://get.erpl.io';
INSTALL anofox_forecast;
LOAD anofox_forecast;
\`\`\`

on any push to \`main\` or \`v*\` release tag, without waiting for a duckdb/community-extensions publication cycle.

## Files

- **\`.github/workflows/MainDistributionPipeline.yml\`** — two new deploy jobs (\`duckdb-lts-deploy\` for v1.4.5 / \`duckdb-latest-deploy\` for v1.5.4) that trigger after their respective build jobs. Gated on \`!cancelled()\` so one flaky matrix entry (e.g. windows_amd64) doesn't block release. Adds \`permissions: id-token: write, contents: read\` at workflow level for the AWS OIDC flow.
- **\`.github/workflows/_extension_deploy.yml\`** — reusable deploy workflow, rewritten to match the statistics-extension version. Gains \`ci_tools_version\` input (needed so LTS deploys parse the arch matrix with the matching \`v1.4-andium\` tools), AWS OIDC role assumption via \`aws-actions/configure-aws-credentials@v1\` (role \`ErplGithubOicdRole\` in eu-west-1), and \`fail-fast: false\` on the deploy matrix.
- **\`scripts/extension-upload.sh\`** — standard DuckDB extension upload helper (native + wasm paths, signature footer / custom-section injection, gzip → S3). Copied verbatim from the statistics repo.

## Trigger semantics

Deploy jobs run on every push (to verify the pipeline is wired up), but the upload script's \`copy_to_latest\` / \`copy_to_versioned\` flags are only \`true\` on \`refs/tags/v*\` or \`refs/heads/main\`. So PRs and feature branches exercise the code path — matrix parse, artifact download, script invocation — but nothing actually hits S3 until the merge.

## Configuration

- **Actions variable \`DEPLOY_S3_BUCKET = get.erpl.io\`** — already set.
- **AWS OIDC role trust policy for \`ErplGithubOicdRole\`** — needs to include \`repo:DataZooDE/anofox-forecast:*\` (anofox-statistics is already covered; adding forecast is a one-line policy update on the AWS side, owned by Erpl). Until that's added, the deploy step will fail with an OIDC role-assumption error — **build jobs continue to work as before, only the S3 push step fails**.

## Security cleanup opportunity

The repo currently has two static AWS credentials as **Actions variables** (\`AWS_ACCESS_KEY_ID\`, \`AWS_SECRET_ACCESS_KEY\`) leftover from a previous deploy attempt. With OIDC now handling role assumption they're not used by any workflow — recommend rotating them out-of-band and removing from Actions once this PR lands.

## Test plan

- [x] Both YAML files pass \`python3 -c \"yaml.safe_load(...)\"\`.
- [x] \`scripts/extension-upload.sh\` copied verbatim from statistics; permissions preserved (executable).
- [ ] CI: deploy jobs execute after build jobs, matrix parse succeeds, artifact download works. Actual S3 upload will fail until the AWS trust policy is updated — that's expected.
- [ ] Once trust policy is updated, next merge to \`main\` publishes \`v1.4.5\` and \`v1.5.4\` variants to \`get.erpl.io\` under both \`latest\` and versioned paths.

Ready to merge whenever the AWS side is coordinated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786263027&installation_id=142929061&pr_number=243&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F243&signature=10db9fd9d1b54ea5e24c8008e0b3c07674031709e341836edd1fe81061d7aa67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->