### PR TITLE
deps: bump anofox-forecast crate to 0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anofox-forecast"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243af6a8cd21ac8c6654cd2f8e984b73ff51f9205be999d67bd14b4ada61218b"
+checksum = "b19a55d4357d5ee6b02f623e9046fa5f51b96611ec794640b0acad4b6f8fecb2"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = { version = "0.15.1", features = ["anomaly"] }
+anofox-forecast = { version = "0.15.3", features = ["anomaly"] }
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates


### PR DESCRIPTION
## Summary

Bumps the \`anofox-forecast\` Rust crate from **0.15.2 → 0.15.3**.

## What's in 0.15.3

Two new opt-in tuning knobs on \`LaplaceForecaster\`:
- \`with_scoring_horizon(usize)\` — override the horizon at which each leaf is scored
- \`with_scoring_window(usize)\` — override the trailing-window size used for likelihood weighting

Both default to the crate's built-in values, so no wiring change is needed in this extension — the currently exposed \`laplace_variant\` and \`laplace_seasonal_batch_init\` params keep their exact meaning. If we later want to expose these knobs to SQL, that's a follow-up PR extending the extension's Laplace param surface.

## Compatibility notes

- \`anofox-regression ^0.5.3\` pin unchanged; matches our existing \`=0.5.3\` workspace pin.
- \`Cargo.lock\` re-locked; no other transitive changes.

## Test plan

- [x] \`cargo check --workspace\` clean.
- [x] \`GEN=ninja make release\` succeeds (LTS 1.4.5 + latest 1.5.4 dual-track).
- [x] \`make test\` — 1274 assertions passing (49 \`require json\` skips are the usual local-shell gate).
- [ ] CI green across Linux / macOS / Windows / Wasm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786279532&installation_id=142929061&pr_number=245&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F245&signature=8fcc15af8fabee771bcb59737f096e0683fde7ad82bdd245eaa776729a174fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->