### PR TITLE
docs: document the Laplace distributional forecaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@
 > This extension is in early development, so bugs and breaking changes are expected.
 > Please use the [issues page](https://github.com/DataZooDE/anofox-forecast/issues) to report bugs or request features.
 
-A time series forecasting extension for DuckDB with 32 models, data preparation, and analytics — all in pure SQL.
+A time series forecasting extension for DuckDB with 33 models, data preparation, and analytics — all in pure SQL.
 
 
 ## ✨ Key Features
 
-### 🎯 Forecasting (32 Models)
+### 🎯 Forecasting (33 Models)
 - **AutoML**: AutoETS, AutoARIMA, AutoMFLES, AutoMSTL, AutoTBATS
 - **Statistical**: ETS, ARIMA, Theta, Holt-Winters, Seasonal Naive
 - **Advanced**: TBATS, MSTL, MFLES (multiple seasonality)
 - **Intermittent Demand**: Croston, ADIDA, IMAPA, TSB
+- **Distributional**: Laplace (streaming likelihood-weighted mixture, three zero-config selectors: `auto` / `auto_aid` / `skaters`)
 - **Exogenous Variables**: ARIMAX, ThetaX, MFLESX (external regressors support)
 
 ### 📊 Complete Workflow
@@ -209,7 +210,7 @@ For complete function signatures, parameters, and detailed documentation, see th
 | **Conformal Prediction** | Distribution-free prediction intervals | [11-conformal-prediction.md](docs/api/11-conformal-prediction.md) |
 | **Feature Extraction** | 117 tsfresh-compatible features | [20-feature-extraction.md](docs/api/20-feature-extraction.md) |
 
-### Model Reference (32 Models)
+### Model Reference (33 Models)
 
 | Category | Models | Reference |
 |----------|--------|-----------|
@@ -219,6 +220,7 @@ For complete function signatures, parameters, and detailed documentation, see th
 | **Theta** | Theta, OptimizedTheta, DynamicTheta, AutoTheta | [theta/](docs/reference/models/theta/) |
 | **Multi-Seasonal** | MFLES, MSTL, TBATS (+ Auto variants) | [multi-seasonal/](docs/reference/models/multi-seasonal/) |
 | **Intermittent Demand** | Croston, CrostonSBA, ADIDA, IMAPA, TSB | [intermittent/](docs/reference/models/intermittent/) |
+| **Distributional** | Laplace (variants: auto, auto_aid, skaters) | [distributional/laplace.md](docs/reference/models/distributional/laplace.md) |
 
 
 ## 📦 Development

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -123,7 +123,7 @@ Both forms are identical in functionality.
 | `ts_detect_periods_by` | Detect seasonality (multi-series) | `ts_detect_periods_by('tbl', id, date, val)` |
 | `ts_features` | Extract 117 features | `ts_features(date, value)` |
 
-### Forecasting Models (32 Models)
+### Forecasting Models (33 Models)
 
 | Category | Models | Reference |
 |----------|--------|-----------|
@@ -133,6 +133,7 @@ Both forms are identical in functionality.
 | **Theta** | `Theta`, `OptimizedTheta`, `DynamicTheta`, `DynamicOptimizedTheta`, `AutoTheta` | [theta/](reference/models/theta/) |
 | **Multi-Seasonal** | `MFLES`, `AutoMFLES`, `MSTL`, `AutoMSTL`, `TBATS`, `AutoTBATS` | [multi-seasonal/](reference/models/multi-seasonal/) |
 | **Intermittent Demand** | `CrostonClassic`, `CrostonOptimized`, `CrostonSBA`, `ADIDA`, `IMAPA`, `TSB` | [intermittent/](reference/models/intermittent/) |
+| **Distributional** | `Laplace` (variants: `auto`, `auto_aid`, `skaters`) | [distributional/laplace.md](reference/models/distributional/laplace.md) |
 
 ### Evaluation Metrics (12 Metrics)
 

--- a/docs/api/07-forecasting.md
+++ b/docs/api/07-forecasting.md
@@ -4,11 +4,11 @@
 
 ## Overview
 
-The extension provides 32 forecasting models ranging from simple baselines to sophisticated state-space methods.
+The extension provides 33 forecasting models ranging from simple baselines to sophisticated state-space methods and streaming distributional forecasters.
 
 **Use this document to:**
 - Generate point forecasts and prediction intervals for single or multiple series
-- Choose from 32 models: baselines (Naive, SMA), exponential smoothing (ETS, Holt-Winters), state-space (ARIMA), multi-seasonal (MSTL, TBATS), and intermittent demand (Croston, TSB)
+- Choose from 33 models: baselines (Naive, SMA), exponential smoothing (ETS, Holt-Winters), state-space (ARIMA), multi-seasonal (MSTL, TBATS), intermittent demand (Croston, TSB), and distributional (Laplace)
 - Use automatic model selection (AutoETS, AutoARIMA, AutoTheta) when unsure
 - Incorporate exogenous variables with supported models
 - Understand the detect-then-forecast workflow for seasonal data
@@ -122,12 +122,13 @@ SELECT * FROM ts_forecast_by(
 |---------------------|-------------------|
 | No trend, no seasonality | `Naive`, `SES`, `SESOptimized` |
 | Trend, no seasonality | `Holt`, `Theta`, `RandomWalkDrift` |
-| Seasonality (single period) | `SeasonalNaive`, `HoltWinters`, `SeasonalES` |
+| Seasonality (single period) | `SeasonalNaive`, `HoltWinters`, `SeasonalES`, `Laplace` |
 | Multiple seasonalities | `MSTL`, `MFLES`, `TBATS` |
-| Intermittent demand (many zeros) | `CrostonClassic`, `CrostonSBA`, `TSB` |
-| Unknown characteristics | `AutoETS`, `AutoARIMA`, `AutoTheta` |
+| Intermittent demand (many zeros) | `CrostonClassic`, `CrostonSBA`, `TSB`, `Laplace` (with `auto_aid`) |
+| Unknown characteristics | `AutoETS`, `AutoARIMA`, `AutoTheta`, `Laplace` |
+| Streaming / distributional | `Laplace` |
 
-## Supported Models (32 Models)
+## Supported Models (33 Models)
 
 ### Automatic Selection Models (6)
 | Model | Description | Optional Params |
@@ -193,6 +194,23 @@ SELECT * FROM ts_forecast_by(
 | `ADIDA` | Aggregate-Disaggregate IDA | — |
 | `IMAPA` | Intermittent Multiple Aggregation | — |
 | `TSB` | Teunter-Syntetos-Babai method | *alpha_d*, *alpha_p* |
+
+### Distributional Models (1)
+
+Streaming likelihood-weighted mixture of leaves (EMA / drift / AR(1) / damped-Holt + optional seasonal / distribution-family leaves). Point + interval forecasts; the full mixture parameters will be exposed by the upcoming `ts_forecast_dist_by` (PR B).
+
+| Model | Description | Optional |
+|-------|-------------|----------|
+| `Laplace` | Streaming distributional forecaster with three zero-config selectors (`auto` / `auto_aid` / `skaters`) | *seasonal_period*, *laplace_variant*, *laplace_seasonal_batch_init* |
+
+**Variants** (`laplace_variant`):
+- `auto` (default) — balanced for smooth / continuous series with adequate history
+- `auto_aid` — AID-based distribution-family selection; best for retail SKU / intermittent counts
+- `skaters` — fuller skaters ensemble (multi-h scoring, stacking, larger leaf set); slower, more robust
+
+**Batch init** (`laplace_seasonal_batch_init: 1`) initialises the seasonal-EMA phase levels from the last training cycle. Safe on stationary or amplitude-declining seasonal series; avoid on growing amplitude or phase-shifted seasonality (the softmax abandons the seasonal-EMA leaf and the forecast collapses to flat).
+
+See [reference/models/distributional/laplace.md](../reference/models/distributional/laplace.md) for the full trade-off table and worked examples.
 
 ---
 

--- a/docs/guides/02-model-selection.md
+++ b/docs/guides/02-model-selection.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The extension provides 32 forecasting models. This guide helps you select the right one.
+The extension provides 33 forecasting models. This guide helps you select the right one.
 
 **Use this guide to:**
 - Analyze your data's characteristics (trend, seasonality, intermittency)
@@ -40,10 +40,11 @@ GROUP BY product_id;
 |---------------|-------------------|-----|
 | No clear patterns | `Naive`, `SES`, `SESOptimized` | Simple baselines work well |
 | Upward/downward trend | `Holt`, `Theta`, `RandomWalkDrift` | Captures trend component |
-| Single seasonal pattern | `SeasonalNaive`, `HoltWinters`, `SeasonalES` | Models one seasonal cycle |
+| Single seasonal pattern | `SeasonalNaive`, `HoltWinters`, `SeasonalES`, `Laplace` | Models one seasonal cycle |
 | Multiple seasons (e.g., weekly + yearly) | `MSTL`, `MFLES`, `TBATS` | Handles complex seasonality |
-| Many zeros (intermittent demand) | `CrostonClassic`, `CrostonSBA`, `TSB` | Specialized for sparse data |
-| Unknown patterns | `AutoETS`, `AutoARIMA`, `AutoTheta` | Automatic model selection |
+| Many zeros (intermittent demand) | `CrostonClassic`, `CrostonSBA`, `TSB`, `Laplace` (`auto_aid`) | Specialized for sparse data; AID leaf selection for retail counts |
+| Unknown patterns | `AutoETS`, `AutoARIMA`, `AutoTheta`, `Laplace` | Automatic model selection |
+| Need speed on large panels | `Laplace`, `SeasonalES` | Streaming leaves; ~30× faster than AutoETS on M5-monthly |
 
 ## Model Categories
 
@@ -117,6 +118,31 @@ SELECT * FROM ts_forecast_by('inventory', id, date, demand, 'CrostonSBA', 12, '1
 SELECT * FROM ts_forecast_by('inventory', id, date, demand, 'TSB', 12, '1d');
 ```
 
+### Distributional (Laplace)
+
+Streaming likelihood-weighted mixture — one call, three zero-config selectors. Fast (~30× faster than AutoETS on M5-monthly), competitive on MAE, non-negative-safe on `auto` / `auto_aid`.
+
+```sql
+-- Default: auto — balanced for smooth / continuous series
+SELECT * FROM ts_forecast_by('sales', id, ds, y, 'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12'});
+
+-- Retail / intermittent counts — AID-based leaf selection
+SELECT * FROM ts_forecast_by('sales', id, ds, y, 'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12', 'laplace_variant': 'auto_aid'});
+
+-- Fuller ensemble — slower, more robust
+SELECT * FROM ts_forecast_by('sales', id, ds, y, 'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12', 'laplace_variant': 'skaters'});
+
+-- Opt-in batch init — helps on stationary / amplitude-declining series
+-- (avoid on growing amplitude / phase-shifted seasonality — collapses the forecast)
+SELECT * FROM ts_forecast_by('sales', id, ds, y, 'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12', 'laplace_seasonal_batch_init': '1'});
+```
+
+See [reference/models/distributional/laplace.md](../reference/models/distributional/laplace.md) for the full variant trade-off table and benchmark numbers.
+
 ## Comparing Models
 
 Always compare multiple models using cross-validation:
@@ -154,11 +180,13 @@ ORDER BY avg_mae;
 
 | Scenario | First Try | Alternative |
 |----------|-----------|-------------|
-| Don't know data characteristics | `AutoETS` | `AutoARIMA` |
+| Don't know data characteristics | `AutoETS` | `Laplace` (`auto`) |
 | Daily retail sales | `HoltWinters` | `MSTL` |
+| Monthly retail SKU counts | `Laplace` (`auto_aid`) | `AutoTheta` |
 | Weekly financial data | `Theta` | `AutoETS` |
 | Hourly sensor data | `MFLES` | `MSTL` |
-| Spare parts demand | `CrostonSBA` | `TSB` |
+| Spare parts demand | `CrostonSBA` | `Laplace` (`auto_aid`) |
+| Large panel, need speed | `Laplace` | `SeasonalES` |
 | Short series (< 20 points) | `Naive` | `SES` |
 
 ---

--- a/docs/reference/models/distributional/laplace.md
+++ b/docs/reference/models/distributional/laplace.md
@@ -1,0 +1,164 @@
+# Laplace
+
+> Streaming distributional forecaster — likelihood-weighted mixture of leaves with three zero-config selectors
+
+## Signature
+
+```sql
+-- Multiple series (grouped)
+SELECT * FROM ts_forecast_by('table', group_col, date_col, value_col,
+    'Laplace', horizon, frequency, params);
+```
+
+## Description
+
+A streaming distributional shell over EMA / drift / AR(1) / damped-Holt leaves — inspired by [microprediction/skaters](https://github.com/microprediction/skaters). Each leaf produces a per-horizon predictive distribution; the mixture weights update online by likelihood, so the shell adapts to regime shifts without a batch refit. Point forecasts come from the moment-match of the per-horizon GaussianMixture; intervals from the requested confidence level.
+
+Three zero-config selectors decide which leaves populate the pool. The point-forecast surface is what `ts_forecast_by` returns today; per-horizon mixture parameters (weights, means, stds) will be exposed by the upcoming `ts_forecast_dist_by` table function (PR B of the distributional series).
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `horizon` | INTEGER | Yes | — | Number of periods to forecast |
+| `seasonal_period` | INTEGER | No | none | Seasonal period — adds a `SeasonalEmaLeaf` to the pool |
+| `laplace_variant` | VARCHAR | No | `'auto'` | Selector: `auto`, `auto_aid`, `skaters` |
+| `laplace_seasonal_batch_init` | BOOLEAN | No | false | Batch-init the seasonal-EMA phase levels from the last training cycle |
+| `confidence_level` | DOUBLE | No | 0.90 | Confidence for prediction intervals |
+
+## Variant Selector
+
+| Variant | Leaf pool | Best for |
+|---------|-----------|----------|
+| `auto` (default) | EMA / drift / AR(1) / damped-Holt (+ seasonal-EMA if `seasonal_period` set) | Smooth continuous series with adequate history — economic, financial, non-demand |
+| `auto_aid` | Above + AID-driven distribution family (Poisson / NegativeBinomial / RectifiedNormal / seasonal-Croston) | Retail SKU / intermittent-demand counts |
+| `skaters` | Full skaters ensemble — multi-h scoring, stacking, larger leaf set (Yeo-Johnson, fractional-diff, OU, terminal-CRPS) | Slower, more robust; use when accuracy matters more than latency |
+
+**Empirical guidance** (from `anofox-forecast`'s M-competition benchmarks):
+
+| Panel | Best selector |
+|-------|---------------|
+| Retail counts / intermittent (M5-Daily, dominick) | `auto_aid` — competitive with AutoETS at ~30–42× the speed |
+| Smooth economic / continuous (M3 monthly, M4 daily) | `auto` — close to AutoTheta, +5–15% on well-behaved data |
+| Short-history seasonal (N < 50, tourism_yearly) | Streaming leaves haven't warmed up — use `AutoTheta` instead |
+| Growing amplitude / phase-shifted seasonal | Any Laplace — but **do not enable `laplace_seasonal_batch_init`** (see below) |
+
+## The batch-init trade-off
+
+`laplace_seasonal_batch_init: 1` initialises the seasonal-EMA phase levels from the last training cycle instead of the streaming softmax warmup. Behaviour, measured on `anofox-forecast`'s reference synthetics ([sipemu/anofox-forecast#195](https://github.com/sipemu/anofox-forecast/issues/195)):
+
+| Amplitude regime | With batch_init | Recommendation |
+|------------------|-----------------|----------------|
+| Constant amplitude | MAE 2.18 → 0.07 on strong-seasonal N=48 | **Enable** |
+| Declining amplitude (recent < earlier) | 5.49× → 1.10× peak-ratio recovery on regime change | **Enable** |
+| Growing amplitude (retail expanding) | Softmax abandons seasonal-EMA for a differenced-EMA leaf → forecast collapses to flat | **Avoid** |
+| Phase-shifted seasonality | Same failure mode — collapse to flat | **Avoid** |
+| Trending panels (M-competition tourism-shape) | Batch-init additive seasonal-EMA displaces the multiplicative seasonal leaf | **Avoid** |
+
+Rule of thumb: safe on stationary or declining-amplitude series; enable per pipeline once you've classified the amplitude regime. Default off in this extension.
+
+The `model_name` column tags the state so downstream code can filter:
+
+```
+Laplace(auto)                              -- no seasonal
+Laplace(auto,seasonal=7)                   -- weekly seasonal
+Laplace(auto_aid,seasonal=12)              -- monthly retail counts
+Laplace(auto,seasonal=12,batch_init)       -- opt-in batch init active
+Laplace(skaters,seasonal=7)                -- fuller ensemble
+```
+
+## Returns
+
+Same shape as any `ts_forecast_by` call: `(group_col, forecast_step, ds, yhat, yhat_lower, yhat_upper, model_name)`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `group_col` | ANY | Series identifier |
+| `forecast_step` | INTEGER | 1..horizon |
+| `<date_col>` | (same as input) | Forecast timestamp |
+| `yhat` | DOUBLE | Point forecast — mean of the mixture |
+| `yhat_lower` / `yhat_upper` | DOUBLE | Prediction interval at `confidence_level` |
+| `model_name` | VARCHAR | Tagged variant + seasonal + batch_init state |
+
+## SQL Examples
+
+### Default — auto on monthly retail
+
+```sql
+-- 12-month forecast, weekly seasonal_period not applicable to monthly data;
+-- for monthly retail use seasonal_period=12
+SELECT * FROM ts_forecast_by(
+    'sales_monthly', product_id, ds, y,
+    'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12'}
+);
+```
+
+### Intermittent counts — auto_aid
+
+```sql
+-- Retail SKU with many zero-days; AID picks Poisson/NegBin/Croston leaves
+SELECT * FROM ts_forecast_by(
+    'sales_daily', item_id, ds, y,
+    'Laplace', 28, '1d',
+    MAP{'seasonal_period': '7', 'laplace_variant': 'auto_aid'}
+);
+```
+
+### Amplitude-declining seasonal series — batch_init
+
+```sql
+-- Series where recent seasonal amplitude is smaller than historical.
+-- Batch init recovers the recent-cycle level; without it the streaming
+-- warmup can leave the seasonal-EMA leaf under-weighted.
+SELECT * FROM ts_forecast_by(
+    'sales_monthly', product_id, ds, y,
+    'Laplace', 12, '1mo',
+    MAP{'seasonal_period': '12', 'laplace_seasonal_batch_init': '1'}
+);
+```
+
+### STRUCT param syntax (recommended)
+
+```sql
+-- Keeps numeric params typed
+SELECT * FROM ts_forecast_by(
+    'sales_monthly', product_id, ds, y,
+    'Laplace', 12, '1mo',
+    {seasonal_period: 12, laplace_variant: 'auto_aid', laplace_seasonal_batch_init: 1}
+);
+```
+
+### Slice metrics by variant post-hoc
+
+```sql
+-- Fit all three variants, join with actuals, compare per-variant MAE
+WITH fcst AS (
+    SELECT 'auto'     AS variant, * FROM ts_forecast_by('train', id, ds, y, 'Laplace', 12, '1mo', MAP{'seasonal_period':'12','laplace_variant':'auto'})
+    UNION ALL SELECT 'auto_aid', * FROM ts_forecast_by('train', id, ds, y, 'Laplace', 12, '1mo', MAP{'seasonal_period':'12','laplace_variant':'auto_aid'})
+    UNION ALL SELECT 'skaters',  * FROM ts_forecast_by('train', id, ds, y, 'Laplace', 12, '1mo', MAP{'seasonal_period':'12','laplace_variant':'skaters'})
+)
+SELECT variant,
+       ROUND(AVG(ABS(t.y - f.yhat)), 3) AS mae
+FROM fcst f JOIN test t ON f.id = t.id AND f.ds = t.ds
+GROUP BY variant ORDER BY mae;
+```
+
+## Best For
+
+- **Retail / demand panels** — `auto_aid` matches AutoETS accuracy at ~30× the speed on M5-monthly (24k series, 12-month horizon: 0.5 s vs 15 s wall clock).
+- **Large-panel throughput** — Streaming leaves, no per-series solver — DuckDB GROUP BY parallelism gives full-CPU utilisation.
+- **Non-negative bounded targets** — `auto` produces zero negative forecasts on M5-monthly; `auto_aid` produces ≤ 0.003 % — much lower than AutoETS's 7.4 % or AutoTheta's 3.9 %.
+- **Downstream distributional workflows** — per-horizon GaussianMixture available (surfaced via `ts_forecast_dist_by` in the next PR of this series).
+
+## Known Limitations
+
+- **Short-history seasonal panels** (N < 24) — the streaming warmup doesn't complete; consider `laplace_seasonal_batch_init` if you know the amplitude is stationary / declining, else use `AutoTheta`.
+- **Growing amplitude with `batch_init` enabled** — the softmax abandons the seasonal-EMA leaf; the forecast collapses to a flat line. Turn `batch_init` off.
+- **Ultra-sparse daily counts (M5-Daily)** — the mixture stays honest and misses the tail spikes AutoETS damps into; on aggregate MAE it can trail by ~5 %. sMAPE and negative-forecast rate stay best-in-class.
+
+## References
+
+- Reference implementation and upstream benchmarks: [`anofox-forecast::models::laplace`](https://github.com/sipemu/anofox-forecast) (Rust crate).
+- Batch-init trade-off analysis and worked amplitude-decline case: [sipemu/anofox-forecast#195](https://github.com/sipemu/anofox-forecast/issues/195).
+- Full M5-monthly / M5-daily benchmark comparing Laplace vs AutoETS / AutoTheta / SeasEs: attached to the PR series introducing this model.


### PR DESCRIPTION
Closes the docs gap opened by #241, which shipped the Laplace model surface but didn't touch any user-facing documentation. Users had no way to discover \`'Laplace'\` as a model string or the \`laplace_variant\` / \`laplace_seasonal_batch_init\` params.

## Changes

Five files across the docs tree:

- **\`docs/api/07-forecasting.md\`** — new \"Distributional Models (1)\" section with the three variants and both params; model_count bumped 32 → 33; the \"Model Selection Guide\" table now lists \`Laplace\` under Single-seasonal, Intermittent (as \`auto_aid\`), Unknown, and a new Streaming / distributional row.
- **\`docs/API_REFERENCE.md\`** — Distributional row added to the forecasting models table; count bumped.
- **\`README.md\`** — Distributional bullet added to the \"Forecasting\" features; Model Reference table extended; count bumped everywhere it appeared.
- **\`docs/guides/02-model-selection.md\`** — Laplace threaded through the characteristics-to-models matrix, a new \"Distributional (Laplace)\" subsection with worked examples for each variant + batch_init, and two new rows in the Quick Reference cheatsheet (monthly retail counts, large-panel speed).
- **\`docs/reference/models/distributional/laplace.md\`** (new) — full model reference page following the \`theta/auto_theta.md\` template. Includes:
  - Variant selector table with empirical guidance (retail vs continuous vs short-history)
  - Batch-init trade-off matrix (safe on stationary/declining, unsafe on growing amplitude / phase-shifted) with links to [sipemu/anofox-forecast#195](https://github.com/sipemu/anofox-forecast/issues/195)
  - Returned columns
  - Worked SQL examples: MAP + STRUCT syntax + per-variant MAE-slicing pattern for post-hoc comparison
  - Best For / Known Limitations sections
  - Upstream references

## Test plan

- [x] Every SQL snippet in the new/updated docs was verified against a fresh release build following the project's docs-verification convention (\`feedback_verify_sql_docs\` memory).
- [x] Model names appear as documented: \`Laplace(auto,seasonal=12)\`, \`Laplace(auto_aid,seasonal=7)\`, \`Laplace(auto,seasonal=12,batch_init)\`, \`Laplace(skaters,seasonal=12)\`.
- [ ] CI green.

## Follow-ups filed separately (not in this PR)

- **#244** — Update the Claude Code skill at \`.claude/skills/anofox-forecast/\` (currently stamped v0.4.6; missing Laplace, STRUCT param syntax, the removed \`ts_backtest_auto_by\`, and other API drift).
- **PR B (future)** — \`ts_forecast_dist_by\` returning per-horizon GaussianMixture parameters. When it lands, this reference page should gain a section documenting the wider distributional surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786279578&installation_id=142929061&pr_number=246&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F246&signature=815924b5434c3096506f4d51898d2a971c8e1230f1de6f522a7edcd5dc9d2df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->