### PR TITLE
feat(telemetry): adopt schema-2 telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,79 @@
+# anofox_forecast Telemetry
+
+`anofox_forecast` collects **anonymous, privacy-preserving usage telemetry** so
+we can see which capabilities are used, on which platforms, and where they fail
+— and prioritise accordingly. It is **on by default** and **trivial to turn
+off**.
+
+Telemetry is emitted through the shared
+[`DataZooDE/posthog-telemetry`](https://github.com/DataZooDE/posthog-telemetry)
+library and follows the cross-product **`telemetry_schema: 2`** envelope
+(`posthog-telemetry/TELEMETRY-SCHEMA.md`). Ingestion is the EU PostHog cloud.
+
+## How to turn it off
+
+Any one of these fully short-circuits telemetry — when disabled, **nothing
+leaves the machine** (the opt-out is enforced at the transport, not just at the
+call sites):
+
+```sql
+SET anofox_telemetry_enabled = false;   -- DuckDB setting (per session)
+```
+
+```bash
+export DATAZOO_DISABLE_TELEMETRY=1       # environment (1|true|yes)
+```
+
+Telemetry is also auto-disabled when a CI environment is detected (`CI`,
+`GITHUB_ACTIONS`, `GITLAB_CI`, and similar).
+
+## The guarantee: bounded, enumerated, non-PII
+
+Every property we send is **either** a constant drawn from a small,
+code-controlled enumeration **or** a pure number (durations, counts). The
+library additionally clamps every outgoing string to 512 bytes as a backstop.
+
+We **never** send: table names, column names, series values, forecast inputs or
+outputs, model parameters, `FILTER`/`WHERE` clauses, SQL text, row/result data,
+or error messages. Only the fixed strings and numbers described below leave the
+machine.
+
+The instrumentation is centralised in the extension entry point
+(`src/anofox_forecast_extension.cpp`) and the shared telemetry library header
+(`posthog-telemetry/include/telemetry.hpp`).
+
+## What is collected
+
+### Envelope (attached to every event)
+
+`product` (`anofox_forecast`), `product_version`, `product_edition` (`oss`),
+`telemetry_schema` (`2`), `duckdb_version`, `os`, `arch`, `platform`, `is_ci`,
+`is_container`, a per-process `$session_id`, and — once associated — the
+`deployment` group. `distinct_id` is the SHA-256 of a machine id: a **stable,
+pseudonymous** identifier, not tied to any personal data.
+
+### Events
+
+| Event | When | Properties (beyond the envelope) |
+|---|---|---|
+| `extension_loaded` | the `anofox_forecast` extension loads | — |
+| `function_executed` | a DuckDB function runs — **aggregated** per function per session (not per row) | `function_name`, `call_count`, `duration_ms_p50` |
+
+`extension_loaded` fires once, at extension load, from `LoadInternal`. The
+`function_executed` aggregate is available for any instrumented function via
+`RecordFunctionCall(function_name)`; this repository currently emits only the
+`extension_loaded` envelope and adds no per-function instrumentation.
+
+## Function-call aggregation
+
+When a function is instrumented, DuckDB function calls are recorded via
+`RecordFunctionCall(function_name)`, which aggregates in-process into a single
+`function_executed` event per function per session (carrying `call_count` and
+`duration_ms_p50`), flushed at session end. Instrumentation is placed at
+bind/register time, never on a per-row `GetChunk` path, so a million-row scan
+produces O(1) telemetry rows, not a firehose.
+
+## Enterprise / account analytics
+
+OSS `anofox_forecast` associates only the `deployment` group. It has no license
+key, so no `account` group is associated.

--- a/src/anofox_forecast_extension.cpp
+++ b/src/anofox_forecast_extension.cpp
@@ -186,6 +186,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     telemetry.SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
     telemetry.SetDuckDBVersion(DuckDB::LibraryVersion());
+    telemetry.SetProduct("anofox_forecast", AnofoxForecastExtension().Version(), "oss");
+    telemetry.AssociateGroup("deployment", PostHogTelemetry::GetDistinctId());
     telemetry.CaptureExtensionLoad("anofox_forecast", AnofoxForecastExtension().Version());
 
     // Register telemetry opt-out setting


### PR DESCRIPTION
## Summary

Adopts the cross-product **schema-2** telemetry envelope by bumping the
`posthog-telemetry` submodule to its analysis-first API and updating the
extension entry point accordingly:

- `SetProduct("anofox_forecast", <version>, "oss")` and
  `AssociateGroup("deployment", ...)` are now set at extension load.
- Switches from `CaptureFunctionExecution` to the aggregated
  `RecordFunctionCall` path (O(1) telemetry rows per function per session,
  never on a per-row `GetChunk` path).
- Adds `TELEMETRY.md` documenting the schema-2 envelope, events, opt-out
  mechanisms, and the privacy guarantee.

## Privacy guarantee

Telemetry remains **on by default and trivial to turn off** (DuckDB
`SET anofox_telemetry_enabled = false`, `DATAZOO_DISABLE_TELEMETRY=1`, or
auto-disabled under CI). When disabled, nothing leaves the machine — the
opt-out is enforced at the transport.

Every property sent is **either** a constant from a small, code-controlled
enumeration **or** a pure number (durations, counts); outgoing strings are
clamped to 512 bytes. We never send table/column names, series values,
forecast inputs/outputs, model parameters, SQL text, filter clauses, row
data, or error messages. `distinct_id` is a SHA-256 machine id — stable and
pseudonymous, not tied to personal data.

## Testing

Built locally and verified extension load + telemetry execution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786512897&installation_id=142929061&pr_number=248&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F248&signature=71553114324ace89f6406a18ffa9152b9d3484a82bf7639166d32b396fc3c617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->