### PR TITLE
Tier 6: expose Inspectable + Explainable as ts_forecast_inspect_by / ts_forecast_explain_by

### DIFF
--- a/.claude/skills/anofox-forecast-models/SKILL.md
+++ b/.claude/skills/anofox-forecast-models/SKILL.md
@@ -234,9 +234,54 @@ FROM forecasts
 ORDER BY product_id, forecast_step;
 ```
 
+## Explainability surfaces (Tier 6)
+
+Two macros expose per-group fit-state and forecast decomposition, each
+returning a nullable **wide STRUCT** so the shape is stable across model
+families. Both require the `json` extension.
+
+### `ts_forecast_inspect_by(source, group_col, date_col, target_col, method, params?)`
+
+Fit-state snapshot. Signature returns `TABLE(group_col, inspection STRUCT(...))`.
+`(inspection).model_family` names which sub-fields are populated:
+
+| `model_family` | Key fields |
+|---|---|
+| `Ets` | `spec`, `alpha`, `beta`, `gamma`, `phi`, `trend_component`, `seasonal_component`, `residuals` |
+| `Arima` | `order_p/d/q`, `seasonal_order_P/D/Q/s`, `coefficients`, `aic`, `bic` |
+| `Theta` | `variant`, `theta`, `alpha` |
+| `Tbats` | `seasonal_periods`, `box_cox_lambda`, `selected_config`, `aic` |
+| `Mfles` | `max_rounds`, `multiplicative`, `penalty`, `trend_component`, `seasonal_component` |
+| `Mstl` | `seasonal_periods`, `iterations`, `trend_component`, `seasonal_component` |
+| `Laplace` | `leaf_names`, `leaf_weights`, `horizon_dists_json` |
+
+Fields not in the current family are `NULL`. `raw_json` carries the full serde payload.
+
+Supported models: `AutoETS`, `AutoARIMA`, `AutoTheta`, `AutoTBATS`, `MFLES`, `AutoMFLES`, `MSTL`, `AutoMSTL`, `Laplace`. Others raise `does not implement Inspectable`.
+
+```sql
+-- Read AutoETS smoothing params per group
+SELECT product_id, (inspection).spec, (inspection).alpha
+FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'AutoETS',
+    {seasonal_period: 12});
+```
+
+### `ts_forecast_explain_by(source, group_col, date_col, target_col, method, horizon, params?)`
+
+Per-horizon decomposition. Returns `TABLE(group_col, decomposition STRUCT(horizon, level DOUBLE[], trend DOUBLE[], seasonal DOUBLE[], residual DOUBLE[], named_components_json, raw_json))`. Each array has `horizon` elements; components not produced by a family are `NULL`.
+
+Supported models: `ETS` (fixed spec), `MSTL`, `AutoMSTL`, `Theta`. Others raise `does not implement Explainable`.
+
+```sql
+-- Reconstruct: yhat = level + trend + seasonal + residual
+SELECT product_id, (decomposition).level, (decomposition).trend, (decomposition).seasonal
+FROM ts_forecast_explain_by('sales', product_id, ds, y, 'ETS', 12,
+    {seasonal_period: 12});
+```
+
 See also: `anofox-forecast-data-prep` (clean input required), `anofox-forecast-detection` (produce `seasonal_period`), `anofox-forecast-backtest` (any model string usable in `ts_cv_forecast_by`), `anofox-forecast-eda` (understand series before picking model).
 
 Reference docs:
-- `docs/api/07-forecasting.md`
+- `docs/api/07-forecasting.md` (§ Explainability)
 - `docs/reference/models/distributional/laplace.md` (Laplace deep-dive)
 - `docs/guides/02-model-selection.md`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ set(EXTENSION_SOURCES
     src/scalar_functions/conformal.cpp
     src/scalar_functions/bootstrap.cpp
     src/scalar_functions/ts_forecast_scalar.cpp
+    src/scalar_functions/ts_forecast_inspect_scalar.cpp
     src/aggregate_functions/ts_forecast_agg.cpp
     src/aggregate_functions/ts_changepoints_agg.cpp
     src/aggregate_functions/ts_features_agg.cpp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "chrono",
  "faer",
  "fdars-core",
+ "serde_json",
  "statrs",
  "thiserror 2.0.17",
 ]
@@ -53,11 +54,14 @@ checksum = "b19a55d4357d5ee6b02f623e9046fa5f51b96611ec794640b0acad4b6f8fecb2"
 dependencies = [
  "anofox-regression 0.5.3",
  "anofox-statistics",
+ "bincode",
  "chrono",
  "faer",
  "getrandom 0.2.16",
  "lbfgs",
  "rand 0.8.6",
+ "serde",
+ "serde_json",
  "statrs",
  "thiserror 2.0.17",
  "trueno",
@@ -211,6 +215,15 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/DataZooDE/anofox-forecast-extension"
 
 [workspace.dependencies]
 # Core forecasting library
-anofox-forecast = { version = "0.15.3", features = ["anomaly"] }
+anofox-forecast = { version = "0.15.3", features = ["anomaly", "serde"] }
 
 # Functional data analysis (seasonality, peaks, detrending)
 # Note: default-features disabled to allow WASM builds; features enabled per-target in crates

--- a/crates/anofox-fcst-core/Cargo.toml
+++ b/crates/anofox-fcst-core/Cargo.toml
@@ -18,6 +18,7 @@ faer = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 statrs = { workspace = true }
+serde_json = "1"
 
 # fdars-core with target-specific features
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/anofox-fcst-core/src/forecast.rs
+++ b/crates/anofox-fcst-core/src/forecast.rs
@@ -1723,6 +1723,297 @@ fn forecast_laplace(
     }
 }
 
+/// Fit-state inspection via the crate's `Inspectable` trait.
+///
+/// Fits the requested model, calls `.explanation()`, and returns the
+/// per-family `Explanation` variant as a JSON string. C++ side unpacks
+/// the JSON into a wide STRUCT via `struct_pack + json_extract` in
+/// `ts_forecast_inspect_by`.
+///
+/// Models covered (Inspectable in anofox-forecast 0.15.3):
+/// - AutoETS, AutoARIMA, AutoTheta, AutoTBATS (auto-selection family)
+/// - MFLES, MSTL (multi-seasonal)
+/// - LaplaceForecaster (distributional)
+///
+/// Unsupported models return an `InvalidModel` error naming the model.
+pub fn forecast_inspect(
+    values: &[Option<f64>],
+    options: &ForecastOptions,
+) -> Result<String> {
+    use anofox_forecast::models::exponential::{AutoETS, AutoETSConfig};
+    use anofox_forecast::models::arima::{AutoARIMA, AutoARIMAConfig};
+    use anofox_forecast::models::mstl_forecaster::MSTLForecaster;
+    use anofox_forecast::models::tbats::AutoTBATS;
+    use anofox_forecast::models::theta::AutoTheta;
+    use anofox_forecast::models::{Inspectable, MFLES};
+    use anofox_forecast::prelude::Forecaster;
+
+    let clean_values: Vec<f64> = fill_nulls_interpolate(values);
+    if clean_values.len() < 3 {
+        return Err(ForecastError::InsufficientData {
+            needed: 3,
+            got: clean_values.len(),
+        });
+    }
+
+    let period = if options.auto_detect_seasonality && options.seasonal_period == 0 {
+        detect_seasonality(&clean_values, None)
+            .ok()
+            .and_then(|p| p.first().cloned())
+            .unwrap_or(1) as usize
+    } else if options.seasonal_period > 0 {
+        options.seasonal_period
+    } else {
+        1
+    };
+
+    let ts = make_timeseries(&clean_values)?;
+
+    // Build → fit → introspect, per model. `.explanation()` returns
+    // the typed enum; we serialise to JSON so the wire is one string.
+    let explanation = match options.model {
+        ModelType::AutoETS => {
+            let mut config = if period > 1 {
+                AutoETSConfig::with_period(period)
+            } else {
+                AutoETSConfig::non_seasonal()
+            };
+            if let Some(pool) = options.model_pool.as_deref() {
+                if let Ok(p) = parse_model_pool(pool) {
+                    config = config.with_model_pool(p);
+                }
+            }
+            let mut model = AutoETS::with_config(config);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("AutoETS fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::AutoARIMA => {
+            let config = if period > 1 {
+                AutoARIMAConfig::default().with_seasonal_period(period)
+            } else {
+                AutoARIMAConfig::default()
+            };
+            let mut model = AutoARIMA::with_config(config);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("AutoARIMA fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::AutoTheta => {
+            let mut model = if period > 1 {
+                AutoTheta::seasonal(period)
+            } else {
+                AutoTheta::new()
+            };
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("AutoTheta fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::AutoTBATS => {
+            let periods: Vec<usize> = if !options.seasonal_periods.is_empty() {
+                options.seasonal_periods.clone()
+            } else if period > 1 {
+                vec![period]
+            } else {
+                vec![]
+            };
+            let mut model = AutoTBATS::new(periods);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("AutoTBATS fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::MFLES | ModelType::AutoMFLES => {
+            let periods: Vec<usize> = if !options.seasonal_periods.is_empty() {
+                options.seasonal_periods.clone()
+            } else if period > 1 {
+                vec![period]
+            } else {
+                vec![]
+            };
+            let mut model = MFLES::new(periods);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("MFLES fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::MSTL | ModelType::AutoMSTL => {
+            let periods: Vec<usize> = if !options.seasonal_periods.is_empty() {
+                options.seasonal_periods.clone()
+            } else if period > 1 {
+                vec![period]
+            } else {
+                vec![12]
+            };
+            let mut model = MSTLForecaster::new(periods);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("MSTL fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        ModelType::Laplace => {
+            let variant = options.laplace_variant.unwrap_or_default();
+            let mut model = match variant {
+                LaplaceVariant::Auto => LaplaceForecaster::new().auto(),
+                LaplaceVariant::AutoAid => LaplaceForecaster::new().auto_aid(),
+                LaplaceVariant::Skaters => LaplaceForecaster::new().skaters(),
+            };
+            if period > 1 {
+                model = model.with_seasonal(period);
+            }
+            if options.laplace_seasonal_batch_init && period > 1 {
+                model = model.with_seasonal_batch_init();
+            }
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("Laplace fit failed: {e}"))
+            })?;
+            Inspectable::explanation(&model)
+        }
+        other => {
+            return Err(ForecastError::InvalidModel(format!(
+                "Model '{}' does not implement Inspectable. Supported models: \
+                 AutoETS, AutoARIMA, AutoTheta, AutoTBATS, MFLES, AutoMFLES, MSTL, AutoMSTL, Laplace.",
+                other.name()
+            )));
+        }
+    }
+    .map_err(|e| ForecastError::ComputationError(format!("explanation() failed: {e}")))?;
+
+    serde_json::to_string(&explanation).map_err(|e| {
+        ForecastError::ComputationError(format!("Failed to serialise Explanation: {e}"))
+    })
+}
+
+/// Per-horizon forecast decomposition via the crate's `Explainable` trait.
+///
+/// Fits the model, calls `.explain(horizon)`, and returns the
+/// `ForecastExplanation` (level / trend / seasonal / residual +
+/// named_components) as a JSON string.
+///
+/// Models covered (Explainable in anofox-forecast 0.15.3):
+/// - ETS (fixed-spec)
+/// - MSTLForecaster
+/// - Theta (single-spec, not AutoTheta)
+///
+/// Unsupported models return an `InvalidModel` error naming the model.
+pub fn forecast_explain(
+    values: &[Option<f64>],
+    horizon: usize,
+    options: &ForecastOptions,
+) -> Result<String> {
+    use anofox_forecast::models::explain::Explainable;
+    use anofox_forecast::models::exponential::{ETSSpec, ETS as ETSModel};
+    use anofox_forecast::models::mstl_forecaster::MSTLForecaster;
+    use anofox_forecast::models::theta::Theta;
+    use anofox_forecast::prelude::Forecaster;
+
+    let clean_values: Vec<f64> = fill_nulls_interpolate(values);
+    if clean_values.len() < 3 {
+        return Err(ForecastError::InsufficientData {
+            needed: 3,
+            got: clean_values.len(),
+        });
+    }
+
+    let period = if options.auto_detect_seasonality && options.seasonal_period == 0 {
+        detect_seasonality(&clean_values, None)
+            .ok()
+            .and_then(|p| p.first().cloned())
+            .unwrap_or(1) as usize
+    } else if options.seasonal_period > 0 {
+        options.seasonal_period
+    } else {
+        1
+    };
+
+    let ts = make_timeseries(&clean_values)?;
+
+    let explanation = match options.model {
+        ModelType::ETS => {
+            let spec = options.ets_spec.as_deref().unwrap_or("AAA");
+            let parsed = ETSSpec::from_notation(spec).map_err(|e| {
+                ForecastError::ComputationError(format!("Invalid ETS spec '{spec}': {e}"))
+            })?;
+            let mut model = ETSModel::new(parsed, period);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("ETS fit failed: {e}"))
+            })?;
+            model.explain(horizon)
+        }
+        ModelType::MSTL | ModelType::AutoMSTL => {
+            let periods: Vec<usize> = if !options.seasonal_periods.is_empty() {
+                options.seasonal_periods.clone()
+            } else if period > 1 {
+                vec![period]
+            } else {
+                vec![12]
+            };
+            let mut model = MSTLForecaster::new(periods);
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("MSTL fit failed: {e}"))
+            })?;
+            model.explain(horizon)
+        }
+        ModelType::Theta => {
+            let mut model = if period > 1 {
+                Theta::seasonal(period)
+            } else {
+                Theta::new()
+            };
+            model.fit(&ts).map_err(|e| {
+                ForecastError::ComputationError(format!("Theta fit failed: {e}"))
+            })?;
+            model.explain(horizon)
+        }
+        other => {
+            return Err(ForecastError::InvalidModel(format!(
+                "Model '{}' does not implement Explainable. Supported models: \
+                 ETS, MSTL, AutoMSTL, Theta.",
+                other.name()
+            )));
+        }
+    }
+    .map_err(|e| ForecastError::ComputationError(format!("explain() failed: {e}")))?;
+
+    // ForecastExplanation isn't Serialize; hand-build the JSON.
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "level".to_string(),
+        serde_json::to_value(&explanation.level).unwrap_or(serde_json::Value::Null),
+    );
+    if let Some(trend) = &explanation.trend {
+        obj.insert(
+            "trend".to_string(),
+            serde_json::to_value(trend).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    if let Some(seasonal) = &explanation.seasonal {
+        obj.insert(
+            "seasonal".to_string(),
+            serde_json::to_value(seasonal).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    if let Some(residual) = &explanation.residual {
+        obj.insert(
+            "residual".to_string(),
+            serde_json::to_value(residual).unwrap_or(serde_json::Value::Null),
+        );
+    }
+    let named: serde_json::Value = explanation
+        .named_components
+        .iter()
+        .map(|(k, v)| (k.clone(), serde_json::to_value(v).unwrap_or(serde_json::Value::Null)))
+        .collect::<serde_json::Map<_, _>>()
+        .into();
+    obj.insert("named_components".to_string(), named);
+    serde_json::to_string(&serde_json::Value::Object(obj)).map_err(|e| {
+        ForecastError::ComputationError(format!("Failed to serialise ForecastExplanation: {e}"))
+    })
+}
+
 /// AutoTheta: Automatic selection of best Theta variant (STM, OTM, DSTM, DOTM).
 /// Uses the proper AutoTheta implementation from anofox-forecast library.
 fn forecast_auto_theta(values: &[f64], horizon: usize, period: usize) -> Result<ForecastOutput> {

--- a/crates/anofox-fcst-core/src/forecast.rs
+++ b/crates/anofox-fcst-core/src/forecast.rs
@@ -1736,12 +1736,9 @@ fn forecast_laplace(
 /// - LaplaceForecaster (distributional)
 ///
 /// Unsupported models return an `InvalidModel` error naming the model.
-pub fn forecast_inspect(
-    values: &[Option<f64>],
-    options: &ForecastOptions,
-) -> Result<String> {
-    use anofox_forecast::models::exponential::{AutoETS, AutoETSConfig};
+pub fn forecast_inspect(values: &[Option<f64>], options: &ForecastOptions) -> Result<String> {
     use anofox_forecast::models::arima::{AutoARIMA, AutoARIMAConfig};
+    use anofox_forecast::models::exponential::{AutoETS, AutoETSConfig};
     use anofox_forecast::models::mstl_forecaster::MSTLForecaster;
     use anofox_forecast::models::tbats::AutoTBATS;
     use anofox_forecast::models::theta::AutoTheta;
@@ -1938,9 +1935,9 @@ pub fn forecast_explain(
                 ForecastError::ComputationError(format!("Invalid ETS spec '{spec}': {e}"))
             })?;
             let mut model = ETSModel::new(parsed, period);
-            model.fit(&ts).map_err(|e| {
-                ForecastError::ComputationError(format!("ETS fit failed: {e}"))
-            })?;
+            model
+                .fit(&ts)
+                .map_err(|e| ForecastError::ComputationError(format!("ETS fit failed: {e}")))?;
             model.explain(horizon)
         }
         ModelType::MSTL | ModelType::AutoMSTL => {
@@ -1952,9 +1949,9 @@ pub fn forecast_explain(
                 vec![12]
             };
             let mut model = MSTLForecaster::new(periods);
-            model.fit(&ts).map_err(|e| {
-                ForecastError::ComputationError(format!("MSTL fit failed: {e}"))
-            })?;
+            model
+                .fit(&ts)
+                .map_err(|e| ForecastError::ComputationError(format!("MSTL fit failed: {e}")))?;
             model.explain(horizon)
         }
         ModelType::Theta => {
@@ -1963,9 +1960,9 @@ pub fn forecast_explain(
             } else {
                 Theta::new()
             };
-            model.fit(&ts).map_err(|e| {
-                ForecastError::ComputationError(format!("Theta fit failed: {e}"))
-            })?;
+            model
+                .fit(&ts)
+                .map_err(|e| ForecastError::ComputationError(format!("Theta fit failed: {e}")))?;
             model.explain(horizon)
         }
         other => {
@@ -2005,7 +2002,12 @@ pub fn forecast_explain(
     let named: serde_json::Value = explanation
         .named_components
         .iter()
-        .map(|(k, v)| (k.clone(), serde_json::to_value(v).unwrap_or(serde_json::Value::Null)))
+        .map(|(k, v)| {
+            (
+                k.clone(),
+                serde_json::to_value(v).unwrap_or(serde_json::Value::Null),
+            )
+        })
         .collect::<serde_json::Map<_, _>>()
         .into();
     obj.insert("named_components".to_string(), named);

--- a/crates/anofox-fcst-core/src/lib.rs
+++ b/crates/anofox-fcst-core/src/lib.rs
@@ -67,8 +67,8 @@ pub use filter::{
     diff, drop_edge_zeros, drop_leading_zeros, drop_trailing_zeros, is_constant, is_short,
 };
 pub use forecast::{
-    forecast, forecast_with_exog, list_models, ExogenousData, ForecastOptions, ForecastOptionsExog,
-    ForecastOutput, LaplaceVariant, ModelType,
+    forecast, forecast_explain, forecast_inspect, forecast_with_exog, list_models, ExogenousData,
+    ForecastOptions, ForecastOptionsExog, ForecastOutput, LaplaceVariant, ModelType,
 };
 pub use gaps::{detect_frequency, fill_forward, fill_gaps};
 pub use imputation::{

--- a/crates/anofox-fcst-ffi/src/lib.rs
+++ b/crates/anofox-fcst-ffi/src/lib.rs
@@ -3830,6 +3830,281 @@ pub unsafe extern "C" fn anofox_ts_forecast_exog(
 }
 
 // ============================================================================
+// Forecast Explainability (Inspectable + Explainable)
+// ============================================================================
+
+/// Allocate a NUL-terminated C string on the FFI heap and hand ownership to the
+/// caller. Returns null if allocation fails.
+///
+/// # Safety
+/// The caller must eventually free the returned pointer via `anofox_free_string`.
+unsafe fn alloc_c_string(s: &str) -> *mut c_char {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let buf = malloc(len + 1) as *mut c_char;
+    if buf.is_null() {
+        return ptr::null_mut();
+    }
+    ptr::copy_nonoverlapping(bytes.as_ptr() as *const c_char, buf, len);
+    *buf.add(len) = 0;
+    buf
+}
+
+/// Free a C string previously allocated by an inspect / explain call.
+///
+/// # Safety
+/// `ptr` must be either null or a pointer previously returned by one of
+/// `anofox_ts_forecast_inspect` / `anofox_ts_forecast_explain` via their
+/// `out_json` out-argument.
+#[no_mangle]
+pub unsafe extern "C" fn anofox_free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        free(ptr as *mut _);
+    }
+}
+
+/// Fit the requested model and serialise its `Inspectable::explanation()`
+/// snapshot as JSON.
+///
+/// The JSON structure is the serde-serialised
+/// `anofox_forecast::models::inspect::Explanation` enum: an object with a
+/// single key equal to the model family (e.g. `AutoETS`, `Arima`,
+/// `Laplace`) whose value is the per-family payload struct.
+///
+/// # Arguments
+/// * `values`, `validity`, `length` — series (validity may be null for
+///   fully-valid data)
+/// * `options` — the same `ForecastOptions` used by `anofox_ts_forecast`;
+///   the `horizon` field is ignored (inspect is a fit-state snapshot)
+/// * `out_json` — receives ownership of a newly-allocated NUL-terminated
+///   JSON string; must be freed with `anofox_free_string`
+/// * `out_error` — optional error slot
+///
+/// # Supported models
+/// AutoETS, AutoARIMA, AutoTheta, AutoTBATS, MFLES, AutoMFLES, MSTL,
+/// AutoMSTL, Laplace. Any other model returns an `InvalidModel` error.
+///
+/// # Safety
+/// Pointer arguments must be valid; `out_json` and `options` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn anofox_ts_forecast_inspect(
+    values: *const c_double,
+    validity: *const u64,
+    length: size_t,
+    options: *const ForecastOptions,
+    out_json: *mut *mut c_char,
+    out_error: *mut AnofoxError,
+) -> bool {
+    if !out_error.is_null() {
+        *out_error = AnofoxError::success();
+    }
+
+    if values.is_null() || options.is_null() || out_json.is_null() {
+        if !out_error.is_null() {
+            (*out_error).set_error(ErrorCode::NullPointer, "Null pointer argument");
+        }
+        return false;
+    }
+    *out_json = ptr::null_mut();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let series = build_series(values, validity, length);
+        let core_opts = build_core_options(&*options)?;
+        anofox_fcst_core::forecast_inspect(&series, &core_opts)
+    }));
+
+    match result {
+        Ok(Ok(json)) => {
+            let ptr = alloc_c_string(&json);
+            if ptr.is_null() {
+                if !out_error.is_null() {
+                    (*out_error).set_error(
+                        ErrorCode::AllocationError,
+                        "Failed to allocate JSON output buffer",
+                    );
+                }
+                return false;
+            }
+            *out_json = ptr;
+            true
+        }
+        Ok(Err(e)) => {
+            if !out_error.is_null() {
+                let code = match e.to_code() {
+                    1 => ErrorCode::NullPointer,
+                    2 => ErrorCode::InvalidInput,
+                    3 => ErrorCode::ComputationError,
+                    4 => ErrorCode::AllocationError,
+                    5 => ErrorCode::InvalidModel,
+                    6 => ErrorCode::InsufficientData,
+                    7 => ErrorCode::InvalidDateFormat,
+                    8 => ErrorCode::InvalidFrequency,
+                    9 => ErrorCode::InvalidInput,
+                    _ => ErrorCode::InternalError,
+                };
+                (*out_error).set_error(code, &e.to_string());
+            }
+            false
+        }
+        Err(_) => {
+            if !out_error.is_null() {
+                (*out_error).set_error(ErrorCode::PanicCaught, "Panic in Rust code");
+            }
+            false
+        }
+    }
+}
+
+/// Fit the requested model and serialise its per-horizon
+/// `Explainable::explain(horizon)` decomposition as JSON.
+///
+/// The JSON has keys `level`, `trend`, `seasonal`, `residual` (each a
+/// Vec\<f64\> of length `horizon`, absent when the family has no such
+/// component) and `named_components` (a map of arbitrary named additive
+/// components).
+///
+/// # Arguments
+/// * `values`, `validity`, `length` — historical series
+/// * `horizon` — number of periods ahead to explain (must equal the
+///   horizon you'll subsequently forecast with; internally we call
+///   `.explain(horizon)`)
+/// * `options` — `ForecastOptions`; `horizon` field is ignored (uses the
+///   explicit `horizon` argument instead)
+/// * `out_json`, `out_error` — see `anofox_ts_forecast_inspect`
+///
+/// # Supported models
+/// ETS (fixed spec), MSTL / AutoMSTL, Theta. Any other model returns an
+/// `InvalidModel` error.
+///
+/// # Safety
+/// Pointer arguments must be valid; `out_json` and `options` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn anofox_ts_forecast_explain(
+    values: *const c_double,
+    validity: *const u64,
+    length: size_t,
+    horizon: size_t,
+    options: *const ForecastOptions,
+    out_json: *mut *mut c_char,
+    out_error: *mut AnofoxError,
+) -> bool {
+    if !out_error.is_null() {
+        *out_error = AnofoxError::success();
+    }
+
+    if values.is_null() || options.is_null() || out_json.is_null() {
+        if !out_error.is_null() {
+            (*out_error).set_error(ErrorCode::NullPointer, "Null pointer argument");
+        }
+        return false;
+    }
+    *out_json = ptr::null_mut();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let series = build_series(values, validity, length);
+        let core_opts = build_core_options(&*options)?;
+        anofox_fcst_core::forecast_explain(&series, horizon, &core_opts)
+    }));
+
+    match result {
+        Ok(Ok(json)) => {
+            let ptr = alloc_c_string(&json);
+            if ptr.is_null() {
+                if !out_error.is_null() {
+                    (*out_error).set_error(
+                        ErrorCode::AllocationError,
+                        "Failed to allocate JSON output buffer",
+                    );
+                }
+                return false;
+            }
+            *out_json = ptr;
+            true
+        }
+        Ok(Err(e)) => {
+            if !out_error.is_null() {
+                let code = match e.to_code() {
+                    1 => ErrorCode::NullPointer,
+                    2 => ErrorCode::InvalidInput,
+                    3 => ErrorCode::ComputationError,
+                    4 => ErrorCode::AllocationError,
+                    5 => ErrorCode::InvalidModel,
+                    6 => ErrorCode::InsufficientData,
+                    7 => ErrorCode::InvalidDateFormat,
+                    8 => ErrorCode::InvalidFrequency,
+                    9 => ErrorCode::InvalidInput,
+                    _ => ErrorCode::InternalError,
+                };
+                (*out_error).set_error(code, &e.to_string());
+            }
+            false
+        }
+        Err(_) => {
+            if !out_error.is_null() {
+                (*out_error).set_error(ErrorCode::PanicCaught, "Panic in Rust code");
+            }
+            false
+        }
+    }
+}
+
+/// Shared FFI → core `ForecastOptions` conversion used by inspect + explain.
+///
+/// Extracted so both entry points parse the buffered string fields
+/// (`model`, `ets_model`, `seasonal_periods_str`, `model_pool`,
+/// `laplace_variant`) identically to `anofox_ts_forecast`.
+unsafe fn build_core_options(
+    opts: &ForecastOptions,
+) -> Result<anofox_fcst_core::ForecastOptions, anofox_fcst_core::ForecastError> {
+    let model_str = CStr::from_ptr(opts.model.as_ptr())
+        .to_str()
+        .unwrap_or("auto");
+    let model_type: anofox_fcst_core::ModelType = model_str.parse().map_err(|_| {
+        anofox_fcst_core::ForecastError::InvalidModel(format!("Unknown model: '{}'", model_str))
+    })?;
+
+    let ets_spec = CStr::from_ptr(opts.ets_model.as_ptr())
+        .to_str()
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let sp_str = CStr::from_ptr(opts.seasonal_periods_str.as_ptr())
+        .to_str()
+        .unwrap_or("");
+    let seasonal_periods = parse_seasonal_periods_str(sp_str);
+
+    let model_pool = CStr::from_ptr(opts.model_pool.as_ptr())
+        .to_str()
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let laplace_variant = CStr::from_ptr(opts.laplace_variant.as_ptr())
+        .to_str()
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(anofox_fcst_core::LaplaceVariant::parse)
+        .transpose()?;
+
+    Ok(anofox_fcst_core::ForecastOptions {
+        model: model_type,
+        ets_spec,
+        horizon: opts.horizon as usize,
+        confidence_level: opts.confidence_level,
+        seasonal_period: opts.seasonal_period as usize,
+        auto_detect_seasonality: opts.auto_detect_seasonality,
+        include_fitted: opts.include_fitted,
+        include_residuals: opts.include_residuals,
+        window: opts.window.max(0) as usize,
+        seasonal_periods,
+        model_pool,
+        laplace_variant,
+        laplace_seasonal_batch_init: opts.laplace_seasonal_batch_init,
+    })
+}
+
+// ============================================================================
 // Data Quality Functions
 // ============================================================================
 

--- a/docs/api/07-forecasting.md
+++ b/docs/api/07-forecasting.md
@@ -315,4 +315,80 @@ SELECT * FROM ts_forecast_exog_by(
 
 ---
 
+## Explainability — inspecting fit state and decomposing forecasts
+
+Two macros expose the crate's `Inspectable` and `Explainable` surfaces
+as wide-STRUCT tables. Both require the `json` extension (auto-loaded
+if `autoload_known_extensions` is on).
+
+### `ts_forecast_inspect_by` — fit-state snapshot per group
+
+Returns one row per group with a nullable, uniformly-typed STRUCT
+`inspection` that carries the union of every family's payload.
+`model_family` names which fields are populated:
+
+| `model_family` | Populated fields |
+|----------------|------------------|
+| `Ets` | `spec`, `alpha`, `beta`, `gamma`, `phi`, `seasonal_period`, `fitted_values`, `trend_component`, `seasonal_component`, `residuals` |
+| `Arima` | `order_p/d/q`, `seasonal_order_P/D/Q/s`, `coefficients`, `aic`, `bic`, `fitted_values`, `residuals` |
+| `Theta` | `variant`, `theta`, `alpha`, `seasonal_period`, `fitted_values`, `residuals` |
+| `Tbats` | `seasonal_periods`, `box_cox_lambda`, `selected_config`, `aic`, `fitted_values`, `residuals` |
+| `Mfles` | `seasonal_period`, `max_rounds`, `multiplicative`, `penalty`, `fitted_values`, `trend_component`, `seasonal_component`, `residuals` |
+| `Mstl` | `seasonal_periods`, `iterations`, `fitted_values`, `trend_component`, `seasonal_component`, `residuals` |
+| `Laplace` | `leaf_names`, `leaf_weights`, `horizon_dists_json`, `fitted_values`, `residuals` |
+| `Regression` | `backend`, `feature_names`, `coefficients`, `intercept`, `coef_std_errors`, `intercept_std_error`, `r_squared`, `fitted_values` |
+
+All other fields are `NULL` for a given family. `raw_json` carries the
+untransformed serde payload for callers that need shapes the wide
+struct doesn't expose (nested Laplace `GaussianMixture` state, etc.).
+
+**Supported models (fit state):** `AutoETS`, `AutoARIMA`, `AutoTheta`,
+`AutoTBATS`, `MFLES`, `AutoMFLES`, `MSTL`, `AutoMSTL`, `Laplace`. Any
+other model errors with `does not implement Inspectable`.
+
+```sql
+-- ETS: read out per-group smoothing parameters
+SELECT product_id,
+       (inspection).spec,
+       (inspection).alpha,
+       (inspection).gamma
+FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'AutoETS',
+    {seasonal_period: 12});
+
+-- Laplace: see the ensemble the shell picked and each leaf's weight
+SELECT product_id,
+       list_zip((inspection).leaf_names, (inspection).leaf_weights)
+FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'Laplace',
+    {seasonal_period: 12, laplace_variant: 'auto_aid'});
+
+-- ARIMA: pull the selected order and BIC
+SELECT product_id,
+       (inspection).order_p, (inspection).order_d, (inspection).order_q,
+       (inspection).bic
+FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'AutoARIMA',
+    {seasonal_period: 12});
+```
+
+### `ts_forecast_explain_by` — per-horizon forecast decomposition
+
+Returns per-group `decomposition` STRUCT with `level` / `trend` /
+`seasonal` / `residual` (each a `DOUBLE[]` of length `horizon`; absent
+components are `NULL`) plus `named_components_json` for family-specific
+extras. `raw_json` carries the untransformed payload.
+
+**Supported models (decomposition):** `ETS` (fixed spec), `MSTL`,
+`AutoMSTL`, `Theta`. Other models error with `does not implement Explainable`.
+
+```sql
+-- Reconstruct: yhat = level + trend + seasonal + residual
+SELECT product_id,
+       (decomposition).level,
+       (decomposition).trend,
+       (decomposition).seasonal
+FROM ts_forecast_explain_by('sales', product_id, ds, y, 'ETS', 12,
+    {seasonal_period: 12});
+```
+
+---
+
 *See also: [Cross-Validation](08-cross-validation.md) | [Evaluation Metrics](09-evaluation-metrics.md)*

--- a/src/anofox_forecast_extension.cpp
+++ b/src/anofox_forecast_extension.cpp
@@ -114,6 +114,7 @@ static void LoadInternal(ExtensionLoader &loader) {
     RegisterTsForecastByFunction(loader);
     RegisterTsForecastAggFunction(loader);
     RegisterTsForecastScalarFunction(loader);
+    RegisterTsForecastInspectScalarFunction(loader);
 
     // Register Metric functions
     RegisterTsMaeFunction(loader);

--- a/src/include/anofox_fcst_ffi.h
+++ b/src/include/anofox_fcst_ffi.h
@@ -2373,6 +2373,81 @@ bool anofox_ts_forecast_exog(const double *values,
                              struct AnofoxError *out_error);
 
 /**
+ * Free a C string previously allocated by an inspect / explain call.
+ *
+ * # Safety
+ * `ptr` must be either null or a pointer previously returned by one of
+ * `anofox_ts_forecast_inspect` / `anofox_ts_forecast_explain` via their
+ * `out_json` out-argument.
+ */
+void anofox_free_string(char *ptr);
+
+/**
+ * Fit the requested model and serialise its `Inspectable::explanation()`
+ * snapshot as JSON.
+ *
+ * The JSON structure is the serde-serialised
+ * `anofox_forecast::models::inspect::Explanation` enum: an object with a
+ * single key equal to the model family (e.g. `AutoETS`, `Arima`,
+ * `Laplace`) whose value is the per-family payload struct.
+ *
+ * # Arguments
+ * * `values`, `validity`, `length` — series (validity may be null for
+ *   fully-valid data)
+ * * `options` — the same `ForecastOptions` used by `anofox_ts_forecast`;
+ *   the `horizon` field is ignored (inspect is a fit-state snapshot)
+ * * `out_json` — receives ownership of a newly-allocated NUL-terminated
+ *   JSON string; must be freed with `anofox_free_string`
+ * * `out_error` — optional error slot
+ *
+ * # Supported models
+ * AutoETS, AutoARIMA, AutoTheta, AutoTBATS, MFLES, AutoMFLES, MSTL,
+ * AutoMSTL, Laplace. Any other model returns an `InvalidModel` error.
+ *
+ * # Safety
+ * Pointer arguments must be valid; `out_json` and `options` must be non-null.
+ */
+bool anofox_ts_forecast_inspect(const double *values,
+                                const uint64_t *validity,
+                                size_t length,
+                                const struct ForecastOptions *options,
+                                char **out_json,
+                                struct AnofoxError *out_error);
+
+/**
+ * Fit the requested model and serialise its per-horizon
+ * `Explainable::explain(horizon)` decomposition as JSON.
+ *
+ * The JSON has keys `level`, `trend`, `seasonal`, `residual` (each a
+ * Vec\<f64\> of length `horizon`, absent when the family has no such
+ * component) and `named_components` (a map of arbitrary named additive
+ * components).
+ *
+ * # Arguments
+ * * `values`, `validity`, `length` — historical series
+ * * `horizon` — number of periods ahead to explain (must equal the
+ *   horizon you'll subsequently forecast with; internally we call
+ *   `.explain(horizon)`)
+ * * `options` — `ForecastOptions`; `horizon` field is ignored (uses the
+ *   explicit `horizon` argument instead)
+ * * `out_json`, `out_error` — see `anofox_ts_forecast_inspect`
+ *
+ * # Supported models
+ * ETS (fixed spec), MSTL / AutoMSTL, Theta. Any other model returns an
+ * `InvalidModel` error.
+ *
+ * # Safety
+ * Pointer arguments must be valid; `out_json` and `options` must be non-null.
+ */
+bool anofox_ts_forecast_explain(const double *values,
+                                const uint64_t *validity,
+                                size_t length,
+                                size_t horizon,
+                                const struct ForecastOptions *options,
+                                char **out_json,
+                                struct AnofoxError *out_error);
+
+/**
  * Compute data quality metrics.
  *
  * # Safety

--- a/src/include/anofox_forecast_extension.hpp
+++ b/src/include/anofox_forecast_extension.hpp
@@ -78,6 +78,7 @@ void RegisterTsForecastFunction(ExtensionLoader &loader);
 void RegisterTsForecastByFunction(ExtensionLoader &loader);
 void RegisterTsForecastAggFunction(ExtensionLoader &loader);
 void RegisterTsForecastScalarFunction(ExtensionLoader &loader);
+void RegisterTsForecastInspectScalarFunction(ExtensionLoader &loader);
 void RegisterTsMaeFunction(ExtensionLoader &loader);
 void RegisterTsMseFunction(ExtensionLoader &loader);
 void RegisterTsRmseFunction(ExtensionLoader &loader);

--- a/src/macros/ts_macros.cpp
+++ b/src/macros/ts_macros.cpp
@@ -593,6 +593,129 @@ FROM (
     "SELECT * FROM ts_forecast_by('sales', product_id, date, qty, 'AutoETS', 12, '1d')",
     "forecasting"},
 
+    // ts_forecast_inspect_by: Return per-group fit-state snapshot for Inspectable models.
+    // C++ API: ts_forecast_inspect_by(source, group_col, date_col, target_col, method, params?)
+    //
+    // Underlying scalar returns the serde-serialised Explanation enum
+    // (`{"Ets": {...}}`, `{"Arima": {...}}`, …). This macro unpacks the wire
+    // JSON into a wide, uniformly-typed STRUCT — every field is nullable so
+    // the shape stays stable regardless of which family fit.
+    //
+    // Requires the json extension for json_extract / json_keys.
+    {"ts_forecast_inspect_by", {"source", "group_col", "date_col", "target_col", "method", nullptr}, {{"params", "MAP{}"}, {nullptr, nullptr}},
+R"(
+WITH _raw AS (
+    SELECT
+        group_col,
+        _ts_forecast_inspect_scalar(
+            LIST(target_col::DOUBLE ORDER BY date_col),
+            method,
+            params
+        ) AS _j
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+),
+_tagged AS (
+    SELECT group_col, _j,
+           json_keys(_j)[1] AS _family,
+           '$.' || json_keys(_j)[1] || '.' AS _base
+    FROM _raw
+    WHERE _j IS NOT NULL
+)
+SELECT
+    group_col,
+    struct_pack(
+        model_family        := _family,
+        spec                := json_extract_string(_j, _base || 'spec'),
+        variant             := json_extract_string(_j, _base || 'variant'),
+        backend             := json_extract_string(_j, _base || 'backend'),
+        selected_config     := json_extract_string(_j, _base || 'selected_config'),
+        alpha               := TRY_CAST(json_extract(_j, _base || 'alpha') AS DOUBLE),
+        beta                := TRY_CAST(json_extract(_j, _base || 'beta') AS DOUBLE),
+        gamma               := TRY_CAST(json_extract(_j, _base || 'gamma') AS DOUBLE),
+        phi                 := TRY_CAST(json_extract(_j, _base || 'phi') AS DOUBLE),
+        theta               := TRY_CAST(json_extract(_j, _base || 'theta') AS DOUBLE),
+        aic                 := TRY_CAST(json_extract(_j, _base || 'aic') AS DOUBLE),
+        bic                 := TRY_CAST(json_extract(_j, _base || 'bic') AS DOUBLE),
+        r_squared           := TRY_CAST(json_extract(_j, _base || 'r_squared') AS DOUBLE),
+        intercept           := TRY_CAST(json_extract(_j, _base || 'intercept') AS DOUBLE),
+        intercept_std_error := TRY_CAST(json_extract(_j, _base || 'intercept_std_error') AS DOUBLE),
+        box_cox_lambda      := TRY_CAST(json_extract(_j, _base || 'box_cox_lambda') AS DOUBLE),
+        penalty             := TRY_CAST(json_extract(_j, _base || 'penalty') AS DOUBLE),
+        seasonal_period     := TRY_CAST(json_extract(_j, _base || 'seasonal_period') AS BIGINT),
+        seasonal_periods    := TRY_CAST(json_extract(_j, _base || 'seasonal_periods') AS BIGINT[]),
+        iterations          := TRY_CAST(json_extract(_j, _base || 'iterations') AS BIGINT),
+        max_rounds          := TRY_CAST(json_extract(_j, _base || 'max_rounds') AS BIGINT),
+        multiplicative      := TRY_CAST(json_extract(_j, _base || 'multiplicative') AS BOOLEAN),
+        order_p             := TRY_CAST(json_extract(_j, _base || 'order[0]') AS BIGINT),
+        order_d             := TRY_CAST(json_extract(_j, _base || 'order[1]') AS BIGINT),
+        order_q             := TRY_CAST(json_extract(_j, _base || 'order[2]') AS BIGINT),
+        seasonal_order_P    := TRY_CAST(json_extract(_j, _base || 'seasonal_order[0]') AS BIGINT),
+        seasonal_order_D    := TRY_CAST(json_extract(_j, _base || 'seasonal_order[1]') AS BIGINT),
+        seasonal_order_Q    := TRY_CAST(json_extract(_j, _base || 'seasonal_order[2]') AS BIGINT),
+        seasonal_order_s    := TRY_CAST(json_extract(_j, _base || 'seasonal_order[3]') AS BIGINT),
+        coefficients        := TRY_CAST(json_extract(_j, _base || 'coefficients') AS DOUBLE[]),
+        coef_std_errors     := TRY_CAST(json_extract(_j, _base || 'coef_std_errors') AS DOUBLE[]),
+        feature_names       := TRY_CAST(json_extract(_j, _base || 'feature_names') AS VARCHAR[]),
+        leaf_weights        := TRY_CAST(json_extract(_j, _base || 'leaf_weights') AS DOUBLE[]),
+        leaf_names          := TRY_CAST(json_extract(_j, _base || 'leaf_names') AS VARCHAR[]),
+        fitted_values       := TRY_CAST(json_extract(_j, _base || 'fitted_values') AS DOUBLE[]),
+        residuals           := TRY_CAST(json_extract(_j, _base || 'residuals') AS DOUBLE[]),
+        trend_component     := TRY_CAST(json_extract(_j, _base || 'trend_component') AS DOUBLE[]),
+        seasonal_component  := TRY_CAST(json_extract(_j, _base || 'seasonal_component') AS DOUBLE[]),
+        horizon_dists_json  := CAST(json_extract(_j, _base || 'horizon_dists') AS VARCHAR),
+        raw_json            := _j
+    ) AS inspection
+FROM _tagged
+)",
+    "Returns per-group Inspectable fit-state snapshot (coefficients, AIC/BIC, components, residuals) as a wide STRUCT.",
+    "SELECT group_col, (inspection).spec, (inspection).aic FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'AutoETS')",
+    "forecasting"},
+
+    // ts_forecast_explain_by: Return per-group per-horizon forecast decomposition.
+    // C++ API: ts_forecast_explain_by(source, group_col, date_col, target_col, method, horizon, params?)
+    //
+    // Underlying scalar returns JSON with `level`, `trend`, `seasonal`,
+    // `residual` (each a DOUBLE[] of length `horizon`, absent when a family
+    // doesn't produce it) and `named_components` (a JSON object of extra
+    // additive contributions).
+    //
+    // Only ETS (fixed spec), MSTL / AutoMSTL, and Theta implement Explainable;
+    // other models return an InvalidModel error from the underlying scalar.
+    //
+    // Requires the json extension for json_extract.
+    {"ts_forecast_explain_by", {"source", "group_col", "date_col", "target_col", "method", "horizon", nullptr}, {{"params", "MAP{}"}, {nullptr, nullptr}},
+R"(
+WITH _raw AS (
+    SELECT
+        group_col,
+        _ts_forecast_explain_scalar(
+            LIST(target_col::DOUBLE ORDER BY date_col),
+            horizon,
+            method,
+            params
+        ) AS _j
+    FROM query_table(source::VARCHAR)
+    GROUP BY group_col
+)
+SELECT
+    group_col,
+    struct_pack(
+        horizon                := horizon,
+        level                  := TRY_CAST(json_extract(_j, '$.level') AS DOUBLE[]),
+        trend                  := TRY_CAST(json_extract(_j, '$.trend') AS DOUBLE[]),
+        seasonal               := TRY_CAST(json_extract(_j, '$.seasonal') AS DOUBLE[]),
+        residual               := TRY_CAST(json_extract(_j, '$.residual') AS DOUBLE[]),
+        named_components_json  := CAST(json_extract(_j, '$.named_components') AS VARCHAR),
+        raw_json               := _j
+    ) AS decomposition
+FROM _raw
+WHERE _j IS NOT NULL
+)",
+    "Returns per-horizon forecast decomposition (level, trend, seasonal, residual) per group as a wide STRUCT. Supports ETS, MSTL, Theta.",
+    "SELECT group_col, (decomposition).trend, (decomposition).seasonal FROM ts_forecast_explain_by('sales', product_id, ds, y, 'ETS', 12, {seasonal_period: 12})",
+    "forecasting"},
+
     // ts_cv_forecast_by: Generate forecasts for CV splits with parallel fold execution
     // C++ API: ts_cv_forecast_by(ml_folds, group_col, date_col, target_col, method, params)
     // Processes all folds in parallel using DuckDB's vectorization

--- a/src/scalar_functions/ts_forecast_inspect_scalar.cpp
+++ b/src/scalar_functions/ts_forecast_inspect_scalar.cpp
@@ -1,0 +1,318 @@
+#include "anofox_forecast_extension.hpp"
+#include "anofox_fcst_ffi.h"
+#include "duckdb.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include <cstring>
+#include <unordered_set>
+
+namespace duckdb {
+
+// ============================================================================
+// _ts_forecast_inspect_scalar / _ts_forecast_explain_scalar
+//
+// Fit the requested model and return a JSON snapshot of its state.
+//
+// - inspect: model fit-state (Inspectable::explanation → per-family payload)
+//   Signature:
+//     _ts_forecast_inspect_scalar(values LIST(DOUBLE), method VARCHAR, params ANY)
+//     → VARCHAR (JSON)
+//
+// - explain: per-horizon decomposition (Explainable::explain(horizon))
+//   Signature:
+//     _ts_forecast_explain_scalar(values LIST(DOUBLE), horizon INTEGER,
+//                                 method VARCHAR, params ANY)
+//     → VARCHAR (JSON)
+//
+// Both are the per-group workhorses behind the ts_forecast_inspect_by /
+// ts_forecast_explain_by macros. The macros unpack the JSON into a wide
+// STRUCT via struct_pack + json_extract on the C++ side, so the FFI wire
+// stays a single string.
+// ============================================================================
+
+// --- Shared parameter parsing (mirrors ts_forecast_scalar.cpp; kept local
+// to avoid pulling that whole translation unit into this one) ---
+
+static string InspectParseStringParam(const Value &params_value, const string &key, const string &default_val) {
+    if (params_value.IsNull()) return default_val;
+    if (params_value.type().id() == LogicalTypeId::MAP) {
+        auto &map_children = MapValue::GetChildren(params_value);
+        for (auto &child : map_children) {
+            auto &k = StructValue::GetChildren(child)[0];
+            auto &v = StructValue::GetChildren(child)[1];
+            if (k.ToString() == key && !v.IsNull()) return v.ToString();
+        }
+    } else if (params_value.type().id() == LogicalTypeId::STRUCT) {
+        auto &struct_children = StructValue::GetChildren(params_value);
+        auto &child_types = StructType::GetChildTypes(params_value.type());
+        for (idx_t i = 0; i < child_types.size(); i++) {
+            if (child_types[i].first == key && !struct_children[i].IsNull()) {
+                return struct_children[i].ToString();
+            }
+        }
+    }
+    return default_val;
+}
+
+static int64_t InspectParseInt64Param(const Value &params_value, const string &key, int64_t default_val) {
+    string s = InspectParseStringParam(params_value, key, "");
+    if (s.empty()) return default_val;
+    try { return std::stoll(s); } catch (...) { return default_val; }
+}
+
+static void FillForecastOptions(ForecastOptions &opts,
+                                 const string &method,
+                                 const Value &params_val,
+                                 int32_t horizon) {
+    memset(&opts, 0, sizeof(opts));
+    strncpy(opts.model, method.c_str(), sizeof(opts.model) - 1);
+    opts.model[sizeof(opts.model) - 1] = '\0';
+
+    string model_spec = InspectParseStringParam(params_val, "model", "");
+    if (!model_spec.empty()) {
+        strncpy(opts.ets_model, model_spec.c_str(), sizeof(opts.ets_model) - 1);
+        opts.ets_model[sizeof(opts.ets_model) - 1] = '\0';
+    }
+
+    int64_t seasonal_period = InspectParseInt64Param(params_val, "seasonal_period", 0);
+    string seasonal_periods_str = InspectParseStringParam(params_val, "seasonal_periods", "");
+    string model_pool = InspectParseStringParam(params_val, "model_pool", "");
+    string laplace_variant = InspectParseStringParam(params_val, "laplace_variant", "");
+    bool laplace_seasonal_batch_init =
+        InspectParseInt64Param(params_val, "laplace_seasonal_batch_init", 0) != 0;
+
+    opts.horizon = horizon;
+    opts.confidence_level = 0.90;
+    opts.seasonal_period = static_cast<int>(seasonal_period);
+    opts.auto_detect_seasonality = (seasonal_period == 0 && seasonal_periods_str.empty());
+    opts.include_fitted = false;
+    opts.include_residuals = false;
+    opts.window = 0;
+
+    if (!seasonal_periods_str.empty()) {
+        strncpy(opts.seasonal_periods_str, seasonal_periods_str.c_str(),
+                sizeof(opts.seasonal_periods_str) - 1);
+        opts.seasonal_periods_str[sizeof(opts.seasonal_periods_str) - 1] = '\0';
+    }
+    if (!model_pool.empty()) {
+        strncpy(opts.model_pool, model_pool.c_str(), sizeof(opts.model_pool) - 1);
+        opts.model_pool[sizeof(opts.model_pool) - 1] = '\0';
+    }
+    if (!laplace_variant.empty()) {
+        strncpy(opts.laplace_variant, laplace_variant.c_str(),
+                sizeof(opts.laplace_variant) - 1);
+        opts.laplace_variant[sizeof(opts.laplace_variant) - 1] = '\0';
+    }
+    opts.laplace_seasonal_batch_init = laplace_seasonal_batch_init;
+}
+
+// Extract a LIST(DOUBLE) row into a flat (values, validity) pair suitable
+// for the FFI call. Returns false on empty / null lists.
+static bool BuildSeriesFromValueList(Vector &value_list_vec,
+                                     UnifiedVectorFormat &value_list_data,
+                                     idx_t row_idx,
+                                     vector<double> &out_values,
+                                     vector<uint64_t> &out_validity) {
+    auto value_idx = value_list_data.sel->get_index(row_idx);
+    if (!value_list_data.validity.RowIsValid(value_idx)) return false;
+
+    auto value_entries = UnifiedVectorFormat::GetData<list_entry_t>(value_list_data);
+    auto &value_entry = value_entries[value_idx];
+    auto &value_child = ListVector::GetEntry(value_list_vec);
+
+    UnifiedVectorFormat value_child_data;
+    value_child.ToUnifiedFormat(ListVector::GetListSize(value_list_vec), value_child_data);
+    auto value_values = UnifiedVectorFormat::GetData<double>(value_child_data);
+
+    idx_t n = value_entry.length;
+    if (n == 0) return false;
+
+    out_values.assign(n, 0.0);
+    size_t words = (n + 63) / 64;
+    out_validity.assign(words, 0);
+
+    for (idx_t i = 0; i < n; i++) {
+        idx_t child_idx = value_entry.offset + i;
+        auto unified_idx = value_child_data.sel->get_index(child_idx);
+        if (value_child_data.validity.RowIsValid(unified_idx)) {
+            out_values[i] = value_values[unified_idx];
+            out_validity[i / 64] |= (1ULL << (i % 64));
+        }
+    }
+    return true;
+}
+
+// ============================================================================
+// _ts_forecast_inspect_scalar
+// ============================================================================
+
+static void TsForecastInspectScalarExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+    idx_t count = args.size();
+
+    auto &value_list_vec = args.data[0];
+    auto &method_vec = args.data[1];
+    auto &params_vec = args.data[2];
+
+    result.SetVectorType(VectorType::FLAT_VECTOR);
+
+    UnifiedVectorFormat value_list_data, method_data, params_data;
+    value_list_vec.ToUnifiedFormat(count, value_list_data);
+    method_vec.ToUnifiedFormat(count, method_data);
+    params_vec.ToUnifiedFormat(count, params_data);
+
+    for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+        vector<double> values;
+        vector<uint64_t> validity;
+        if (!BuildSeriesFromValueList(value_list_vec, value_list_data, row_idx, values, validity)) {
+            FlatVector::SetNull(result, row_idx, true);
+            continue;
+        }
+
+        auto m_idx = method_data.sel->get_index(row_idx);
+        string method = "AutoETS";
+        if (method_data.validity.RowIsValid(m_idx)) {
+            method = UnifiedVectorFormat::GetData<string_t>(method_data)[m_idx].GetString();
+        }
+
+        Value params_val;
+        auto p_idx = params_data.sel->get_index(row_idx);
+        if (params_data.validity.RowIsValid(p_idx)) {
+            params_val = params_vec.GetValue(row_idx);
+        }
+
+        ForecastOptions opts;
+        FillForecastOptions(opts, method, params_val, /*horizon*/ 1);
+
+        char *out_json = nullptr;
+        AnofoxError error;
+        bool success = anofox_ts_forecast_inspect(
+            values.data(),
+            validity.empty() ? nullptr : validity.data(),
+            values.size(),
+            &opts,
+            &out_json,
+            &error);
+
+        if (!success) {
+            if (error.code == INVALID_MODEL || error.code == INVALID_INPUT) {
+                throw InvalidInputException(string(error.message));
+            }
+            FlatVector::SetNull(result, row_idx, true);
+            continue;
+        }
+
+        string json_out = out_json ? string(out_json) : string();
+        if (out_json) {
+            anofox_free_string(out_json);
+        }
+        result.SetValue(row_idx, Value(std::move(json_out)));
+    }
+}
+
+// ============================================================================
+// _ts_forecast_explain_scalar
+// ============================================================================
+
+static void TsForecastExplainScalarExecute(DataChunk &args, ExpressionState &state, Vector &result) {
+    idx_t count = args.size();
+
+    auto &value_list_vec = args.data[0];
+    auto &horizon_vec = args.data[1];
+    auto &method_vec = args.data[2];
+    auto &params_vec = args.data[3];
+
+    result.SetVectorType(VectorType::FLAT_VECTOR);
+
+    UnifiedVectorFormat value_list_data, horizon_data, method_data, params_data;
+    value_list_vec.ToUnifiedFormat(count, value_list_data);
+    horizon_vec.ToUnifiedFormat(count, horizon_data);
+    method_vec.ToUnifiedFormat(count, method_data);
+    params_vec.ToUnifiedFormat(count, params_data);
+
+    for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+        vector<double> values;
+        vector<uint64_t> validity;
+        if (!BuildSeriesFromValueList(value_list_vec, value_list_data, row_idx, values, validity)) {
+            FlatVector::SetNull(result, row_idx, true);
+            continue;
+        }
+
+        auto h_idx = horizon_data.sel->get_index(row_idx);
+        int32_t horizon = 12;
+        if (horizon_data.validity.RowIsValid(h_idx)) {
+            horizon = UnifiedVectorFormat::GetData<int32_t>(horizon_data)[h_idx];
+        }
+        if (horizon <= 0) {
+            throw InvalidInputException("horizon must be >= 1 (got %d)", static_cast<int>(horizon));
+        }
+
+        auto m_idx = method_data.sel->get_index(row_idx);
+        string method = "ETS";
+        if (method_data.validity.RowIsValid(m_idx)) {
+            method = UnifiedVectorFormat::GetData<string_t>(method_data)[m_idx].GetString();
+        }
+
+        Value params_val;
+        auto p_idx = params_data.sel->get_index(row_idx);
+        if (params_data.validity.RowIsValid(p_idx)) {
+            params_val = params_vec.GetValue(row_idx);
+        }
+
+        ForecastOptions opts;
+        FillForecastOptions(opts, method, params_val, horizon);
+
+        char *out_json = nullptr;
+        AnofoxError error;
+        bool success = anofox_ts_forecast_explain(
+            values.data(),
+            validity.empty() ? nullptr : validity.data(),
+            values.size(),
+            static_cast<size_t>(horizon),
+            &opts,
+            &out_json,
+            &error);
+
+        if (!success) {
+            if (error.code == INVALID_MODEL || error.code == INVALID_INPUT) {
+                throw InvalidInputException(string(error.message));
+            }
+            FlatVector::SetNull(result, row_idx, true);
+            continue;
+        }
+
+        string json_out = out_json ? string(out_json) : string();
+        if (out_json) {
+            anofox_free_string(out_json);
+        }
+        result.SetValue(row_idx, Value(std::move(json_out)));
+    }
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+void RegisterTsForecastInspectScalarFunction(ExtensionLoader &loader) {
+    // _ts_forecast_inspect_scalar(values LIST(DOUBLE), method VARCHAR, params ANY)
+    //   → VARCHAR (JSON)
+    ScalarFunction inspect_func("_ts_forecast_inspect_scalar",
+        {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY},
+        LogicalType::VARCHAR,
+        TsForecastInspectScalarExecute);
+    inspect_func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+    loader.RegisterFunction(inspect_func);
+
+    // _ts_forecast_explain_scalar(values LIST(DOUBLE), horizon INT,
+    //                             method VARCHAR, params ANY) → VARCHAR (JSON)
+    ScalarFunction explain_func("_ts_forecast_explain_scalar",
+        {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::INTEGER,
+         LogicalType::VARCHAR, LogicalType::ANY},
+        LogicalType::VARCHAR,
+        TsForecastExplainScalarExecute);
+    explain_func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+    loader.RegisterFunction(explain_func);
+}
+
+} // namespace duckdb

--- a/test/sql/ts_forecast_inspect_explain.test
+++ b/test/sql/ts_forecast_inspect_explain.test
@@ -1,0 +1,174 @@
+# name: test/sql/ts_forecast_inspect_explain.test
+# description: Tests for ts_forecast_inspect_by / ts_forecast_explain_by (Tier 6 explainability)
+# group: [sql]
+
+require anofox_forecast
+
+require json
+
+# Setup: monthly-seasonal panel with 60 obs per group — enough for AutoETS /
+# AutoARIMA / Laplace / MSTL to fit and expose non-trivial state.
+statement ok
+CREATE TABLE explain_panel AS
+SELECT
+    ('A', 'B', 'C')[(i // 60) + 1] AS product_id,
+    (DATE '2024-01-01' + ((i % 60) || ' month')::INTERVAL)::DATE AS ds,
+    10.0 + 3.0 * sin(2 * pi() * ((i % 60) % 12) / 12.0) + 0.05 * (i % 60) AS y
+FROM generate_series(0, 179) AS t(i);
+
+#######################################
+# ts_forecast_inspect_by — supported models
+#######################################
+
+# AutoETS: family / spec / fitted length
+query IIII
+SELECT product_id,
+       (inspection).model_family,
+       (inspection).seasonal_period,
+       array_length((inspection).fitted_values)
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoETS', {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	Ets	12	60
+B	Ets	12	60
+C	Ets	12	60
+
+# AutoARIMA: order tuple + AIC populated
+query III
+SELECT product_id,
+       (inspection).model_family,
+       (inspection).aic IS NOT NULL
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoARIMA', {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	Arima	true
+B	Arima	true
+C	Arima	true
+
+# Laplace: leaf ensemble metadata
+query III
+SELECT product_id,
+       (inspection).model_family,
+       array_length((inspection).leaf_names) > 0
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'Laplace', {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	Laplace	true
+B	Laplace	true
+C	Laplace	true
+
+# AutoTheta: variant string populated
+query III
+SELECT product_id,
+       (inspection).model_family,
+       (inspection).variant IS NOT NULL
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoTheta', {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	Theta	true
+B	Theta	true
+C	Theta	true
+
+# Cross-family unused fields are NULL — wide STRUCT contract.
+# AutoARIMA has no `spec` field; AutoETS has no `order_p` field.
+query II
+SELECT (inspection).spec, (inspection).order_p
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoARIMA', {seasonal_period: 12})
+WHERE product_id = 'A';
+----
+NULL	0
+
+query II
+SELECT (inspection).spec IS NOT NULL, (inspection).order_p
+FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoETS', {seasonal_period: 12})
+WHERE product_id = 'A';
+----
+true	NULL
+
+#######################################
+# ts_forecast_inspect_by — rejection of non-Inspectable models
+#######################################
+
+statement error
+SELECT * FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'Naive');
+----
+does not implement Inspectable
+
+statement error
+SELECT * FROM ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'SeasonalNaive', {seasonal_period: 12});
+----
+does not implement Inspectable
+
+#######################################
+# ts_forecast_explain_by — supported models (ETS / Theta / MSTL)
+#######################################
+
+# ETS explain: level / trend / seasonal each has `horizon` entries
+query IIIII
+SELECT product_id,
+       (decomposition).horizon,
+       array_length((decomposition).level),
+       array_length((decomposition).trend),
+       array_length((decomposition).seasonal)
+FROM ts_forecast_explain_by('explain_panel', product_id, ds, y, 'ETS', 12, {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	12	12	12	12
+B	12	12	12	12
+C	12	12	12	12
+
+# Theta explain: at least `level` present; seasonal may be optional
+query III
+SELECT product_id,
+       (decomposition).horizon,
+       array_length((decomposition).level)
+FROM ts_forecast_explain_by('explain_panel', product_id, ds, y, 'Theta', 6, {seasonal_period: 12})
+ORDER BY product_id;
+----
+A	6	6
+B	6	6
+C	6	6
+
+# MSTL explain
+query III
+SELECT product_id,
+       (decomposition).horizon,
+       array_length((decomposition).level)
+FROM ts_forecast_explain_by('explain_panel', product_id, ds, y, 'MSTL', 4, {seasonal_periods: '[12]'})
+ORDER BY product_id;
+----
+A	4	4
+B	4	4
+C	4	4
+
+#######################################
+# ts_forecast_explain_by — rejection of non-Explainable models
+#######################################
+
+statement error
+SELECT * FROM ts_forecast_explain_by('explain_panel', product_id, ds, y, 'AutoETS', 12, {seasonal_period: 12});
+----
+does not implement Explainable
+
+statement error
+SELECT * FROM ts_forecast_explain_by('explain_panel', product_id, ds, y, 'Naive', 12);
+----
+does not implement Explainable
+
+#######################################
+# Dual-name alias exposure
+#######################################
+
+query II
+SELECT (inspection).model_family, (inspection).seasonal_period
+FROM anofox_fcst_ts_forecast_inspect_by('explain_panel', product_id, ds, y, 'AutoETS', {seasonal_period: 12})
+WHERE product_id = 'A';
+----
+Ets	12
+
+query II
+SELECT (decomposition).horizon, array_length((decomposition).trend)
+FROM anofox_fcst_ts_forecast_explain_by('explain_panel', product_id, ds, y, 'ETS', 8, {seasonal_period: 12})
+WHERE product_id = 'A';
+----
+8	8


### PR DESCRIPTION
## Summary
- Surface the anofox-forecast crate's `Inspectable` (fit-state) and `Explainable` (per-horizon decomposition) traits as two new SQL table macros: `ts_forecast_inspect_by` and `ts_forecast_explain_by`.
- Both return a **wide, uniformly-typed STRUCT with every field nullable**, so the shape is stable across model families — `(inspection).model_family` (e.g. `Ets`, `Arima`, `Laplace`) tells the caller which fields are populated. `raw_json` carries the untransformed serde payload for shapes we don't flatten (nested Laplace `GaussianMixture` state).
- Cross-language wire is a single JSON string: FFI returns it; C++ macro unpacks it with `json_extract` on a family-based dynamic path. Cheap to extend when new families ship — no bespoke FFI struct per model.

### Coverage

| Surface | Supported models |
|---|---|
| `ts_forecast_inspect_by` | AutoETS, AutoARIMA, AutoTheta, AutoTBATS, MFLES, AutoMFLES, MSTL, AutoMSTL, Laplace |
| `ts_forecast_explain_by` | ETS (fixed spec), MSTL, AutoMSTL, Theta |

Unsupported models raise `Invalid Input Error: … does not implement Inspectable/Explainable`.

### Example
```sql
-- Read AutoETS smoothing params per group
SELECT product_id, (inspection).spec, (inspection).alpha
FROM ts_forecast_inspect_by('sales', product_id, ds, y, 'AutoETS',
    {seasonal_period: 12});

-- Decompose an ETS 12-step forecast into level / trend / seasonal
SELECT product_id, (decomposition).trend, (decomposition).seasonal
FROM ts_forecast_explain_by('sales', product_id, ds, y, 'ETS', 12,
    {seasonal_period: 12});
```

## Test plan
- [x] New `test/sql/ts_forecast_inspect_explain.test` — 12 assertions covering AutoETS / AutoARIMA / AutoTheta / Laplace inspect, ETS / Theta / MSTL explain, cross-family NULL contracts, `anofox_fcst_*` alias exposure, and Invalid-Input error paths for non-Inspectable / non-Explainable models.
- [x] Full local suite: `1274 assertions in 14 test cases` — no regressions.
- [x] Manual smoke tests over 60-obs monthly seasonal panel (AutoETS spec/alpha, AutoARIMA order/AIC, Laplace 19-leaf ensemble, ETS 12-horizon decomposition).
- [ ] CI green on both DuckDB v1.4.5 LTS and v1.5.4 latest matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786606927&installation_id=142929061&pr_number=249&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F249&signature=f216c91bc18d9e4fa682762a462ffccbb51d948d18c816cea249f45d460d5cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->