### PR TITLE
chore: bump DuckDB to v1.5.5 (keep v1.4 LTS)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -47,10 +47,10 @@ jobs:
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
   duckdb-latest-build:
-    name: Build extension binaries (DuckDB latest v1.5.4)
+    name: Build extension binaries (DuckDB latest v1.5.5)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       ci_tools_version: v1.5-variegata
       extension_name: anofox_forecast
       enable_rust: true
@@ -59,13 +59,13 @@ jobs:
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'
 
   duckdb-latest-deploy:
-    name: Deploy extension binaries (v1.5.4)
+    name: Deploy extension binaries (v1.5.5)
     needs: duckdb-latest-build
     if: ${{ !cancelled() }}
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       ci_tools_version: v1.5-variegata
       extension_name: anofox_forecast
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw'


### PR DESCRIPTION
## Summary
- Bumps the `duckdb` submodule from v1.5.4 to v1.5.5.
- Updates `.github/workflows/MainDistributionPipeline.yml`: `duckdb-latest-build` / `duckdb-latest-deploy` jobs now target `duckdb_version: v1.5.5` (names updated accordingly). `ci_tools_version` stays on the rolling `v1.5-variegata` branch (unchanged, auto-tracks).
- Normalizes the v1.4 LTS build to `v1.4.5` — it was already pinned there, so no change was needed on that line; the dual v1.4/v1.5 release matrix (`duckdb-lts-build`/`duckdb-lts-deploy` + `duckdb-latest-build`/`duckdb-latest-deploy`) is otherwise untouched.
- No other genuine version pins found (Makefile, vcpkg.json, CMakeLists.txt) requiring changes.

## Local verification on bigfox
- Build: **pass** — clean `make release` (GEN=ninja), extension artifact produced at `build/release/extension/anofox_forecast/anofox_forecast.duckdb_extension`.
- Tests: **pass** — `build/release/test/unittest` reports "All tests passed (100 skipped tests, 2548 assertions in 28 test cases)" (100 skips are `require json` gated tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475092&installation_model_id=425457&pr_number=251&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F251&signature=416cb3770ba0bdd638b5ffdd9842b6efc0a868f4c98f0b43c253e0edd5b181c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->