### PR TITLE
feat: add feedback banner and guard the table-function entry points

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "posthog-telemetry"]
 	path = posthog-telemetry
 	url = https://github.com/DataZooDE/posthog-telemetry.git
+[submodule "datazoo-banner"]
+	path = datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,10 +206,27 @@ set(EXTENSION_SOURCES
 )
 
 # Build the static extension
+# Feedback banner (header-only). Its banner_shown event goes through
+# posthog-telemetry, so the flag follows TELEMETRY_SUPPORTED -- set after that
+# variable is computed, since reading it earlier yields an empty value and would
+# silently disable the event everywhere.
+set(DATAZOO_BANNER_TELEMETRY ${TELEMETRY_SUPPORTED} CACHE BOOL "" FORCE)
+set(DATAZOO_BANNER_TELEMETRY_INCLUDE_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/posthog-telemetry/include CACHE PATH "" FORCE)
+add_subdirectory(datazoo-banner)
+# This repo puts dependency headers on the global include path rather than
+# relying on target propagation (see posthog-telemetry above), and the extension
+# targets are created by DuckDB's macros in a way that does not pick up the
+# INTERFACE include from target_link_libraries here. Match the local convention.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/datazoo-banner/include)
+
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 
 # Build the loadable extension
 build_loadable_extension(${TARGET_NAME} "" ${EXTENSION_SOURCES})
+
+target_link_libraries(${EXTENSION_NAME} datazoo_banner)
+target_link_libraries(${LOADABLE_EXTENSION_NAME} datazoo_banner)
 
 # Telemetry library + OpenSSL (only when OpenSSL was found)
 set(TELEMETRY_LIBS "")

--- a/README.md
+++ b/README.md
@@ -402,3 +402,17 @@ Special thanks to the DuckDB team for making extensions possible!
 📢 **Follow us** for updates: [@datazoo](https://www.linkedin.com/company/datazoo/)
 
 🚀 **Get started now**: `LOAD 'anofox_forecast';`
+
+## Feedback
+
+If a forecast looks wrong or `anofox_forecast` misbehaves, please
+[open an issue](https://github.com/DataZooDE/anofox-forecast/issues). Forecast quality
+depends on real seasonality, gaps and outliers we cannot reproduce from synthetic
+series, so a report with your data shape is the fastest path to a fix.
+
+If it saved you time, a star on the repo helps other people find it.
+
+The first time you load the extension in an interactive terminal each day, a small
+banner says the same thing. It never prints when output is piped, in notebooks, or in
+CI. Silence it with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.
+

--- a/src/anofox_forecast_extension.cpp
+++ b/src/anofox_forecast_extension.cpp
@@ -8,8 +8,14 @@
 
 #ifdef HAS_POSTHOG_TELEMETRY
 #include "telemetry.hpp"
+#include "anofox_forecast_banner.hpp"
 #endif
 
+
+// Deliberately outside namespace duckdb: the banner library is DuckDB-agnostic
+// and the guard macro refers to this object from every guarded source file.
+const datazoo::BannerInfo ANOFOX_FORECAST_BANNER {
+    "anofox_forecast", "0.1.0", "https://github.com/DataZooDE/anofox-forecast"};
 
 namespace duckdb {
 
@@ -203,6 +209,11 @@ static void LoadInternal(ExtensionLoader &loader) {
         }
     );
 #endif
+
+	datazoo::RegisterBannerOption(loader);
+	// Last, so a load that fails earlier never advertises itself. Silent unless
+	// stderr is a terminal and the ~/.duckdb stamp is over a day old.
+	datazoo::ShowBanner(ANOFOX_FORECAST_BANNER);
 }
 
 void AnofoxForecastExtension::Load(ExtensionLoader &loader) {

--- a/src/anofox_forecast_extension.cpp
+++ b/src/anofox_forecast_extension.cpp
@@ -5,10 +5,10 @@
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "anofox_forecast_banner.hpp"
 
 #ifdef HAS_POSTHOG_TELEMETRY
 #include "telemetry.hpp"
-#include "anofox_forecast_banner.hpp"
 #endif
 
 

--- a/src/include/anofox_forecast_banner.hpp
+++ b/src/include/anofox_forecast_banner.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "datazoo_banner_duckdb.hpp"
+
+// Shared identity for the load banner and the issue-link error footer.
+// External linkage: DATAZOO_GUARD takes the address as a non-type template
+// argument. Defined in anofox_forecast_extension.cpp.
+extern const datazoo::BannerInfo ANOFOX_FORECAST_BANNER;

--- a/src/table_functions/ts_features.cpp
+++ b/src/table_functions/ts_features.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include <unordered_map>
 #include <limits>
+#include "anofox_forecast_banner.hpp"
 
 namespace duckdb {
 
@@ -229,7 +230,7 @@ static void TsFeaturesListExecute(ClientContext &context, TableFunctionInput &da
 }
 
 void RegisterTsFeaturesListFunction(ExtensionLoader &loader) {
-    TableFunction ts_features_list_func("ts_features_list", {}, TsFeaturesListExecute, TsFeaturesListBind);
+    TableFunction ts_features_list_func("ts_features_list", {}, DATAZOO_GUARD(ANOFOX_FORECAST_BANNER, TsFeaturesListExecute), DATAZOO_GUARD(ANOFOX_FORECAST_BANNER, TsFeaturesListBind));
     {
         CreateTableFunctionInfo info(ts_features_list_func);
         FunctionDescription desc;
@@ -304,7 +305,7 @@ static void TsFeaturesConfigTemplateExecute(ClientContext &context, TableFunctio
 }
 
 void RegisterTsFeaturesConfigTemplateFunction(ExtensionLoader &loader) {
-    TableFunction func("ts_features_config_template", {}, TsFeaturesConfigTemplateExecute, TsFeaturesConfigTemplateBind);
+    TableFunction func("ts_features_config_template", {}, DATAZOO_GUARD(ANOFOX_FORECAST_BANNER, TsFeaturesConfigTemplateExecute), DATAZOO_GUARD(ANOFOX_FORECAST_BANNER, TsFeaturesConfigTemplateBind));
     {
         CreateTableFunctionInfo info(func);
         FunctionDescription desc;

--- a/test/sql/feedback.test
+++ b/test/sql/feedback.test
@@ -1,0 +1,30 @@
+# name: test/sql/feedback.test
+# description: Feedback banner wiring: the opt-out knob exists, and errors DuckDB
+#              raises before dispatch are not annotated.
+# group: [sql]
+
+require anofox_forecast
+
+# --- Errors DuckDB raises before dispatch (binder, catalog, arity) are
+#     deliberately NOT annotated -- they are not ours, and claiming them would
+#     send users to the wrong tracker.
+statement error
+SELECT * FROM ts_features_list('bogus');
+----
+Binder Error
+
+# NOTE: no assertion here that a guarded entry point emits the issue footer.
+# The two table functions carrying DATAZOO_GUARD (ts_features_list and
+# ts_features_config_template) take no arguments and cannot fail from SQL --
+# ts_features_list() simply returns its 117 rows. The guards are in place and
+# have nothing to catch today. Add an assertion here if either grows a failure
+# mode, or when guards are extended to the ts_* scalar and aggregate surface.
+
+# --- The opt-out knob exists and is settable. The banner itself cannot be
+#     observed from a .test file at all -- stderr is not a tty here, which is
+#     precisely the guarantee that keeps this suite's expected output unchanged.
+statement ok
+SET datazoo_banner = false;
+
+statement ok
+SET datazoo_banner = true;


### PR DESCRIPTION
Forecast quality depends on real seasonality, gaps and outliers we cannot reproduce from synthetic series, so the users who get a bad forecast are the only ones who can tell us what their data looked like.

Part of a fleet-wide rollout using the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule.

## What changed

**Once-a-day banner on interactive load.** Silent when piped, in notebooks, in CI and under the test runner.

**`DATAZOO_GUARD` on the two table-function entry points** — `ts_features_list`, `ts_features_config_template`.

## Two things to know

**The guards have nothing to catch today.** Both functions take no arguments and cannot fail from SQL — `ts_features_list()` just returns its 117 rows. The large `ts_*` scalar and aggregate surface is deliberately not guarded; that is the entry-points-only scope applied across the anofox fleet. `feedback.test` records this rather than leaving a future reader to wonder why the assertion is missing.

**The banner include had to go on the global include path**, not through `target_link_libraries`. This repo's extension targets are created by DuckDB's macros in a way that does not pick up the INTERFACE include directory — the build failed to find `datazoo_banner_duckdb.hpp` even with the link line present. `posthog-telemetry` is wired the same way here, so this matches the local convention.

## Verified

- Banner once interactively, silent when piped
- **1274 assertions in 14 cases pass**, plus the new `feedback.test` (3 assertions)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-forecast/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788617963&installation_model_id=425457&pr_number=252&repository=DataZooDE%2Fanofox-forecast&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-forecast%2Fpull%2F252&signature=0f99c571872d620a902a50501b9de2fa5cde742dbc58d23332036b26efcdd02a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->